### PR TITLE
Fix macOS FluidSynth unable to find soundfont

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1430,13 +1430,19 @@ if( NOT WIN32 AND NOT APPLE )
 	endif()
 endif()
 
+if( APPLE )
+	set( SOUNDFONT_DEST_DIR "${CMAKE_BINARY_DIR}/${ZDOOM_EXE_NAME}.app/Contents/Resources" )
+else()
+	set( SOUNDFONT_DEST_DIR "$<TARGET_FILE_DIR:zdoom>" )
+endif()
+
 add_custom_command(TARGET zdoom POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different
-	${CMAKE_SOURCE_DIR}/soundfont/uzdoom.sf2 $<TARGET_FILE_DIR:zdoom>/soundfonts/uzdoom.sf2
+	${CMAKE_SOURCE_DIR}/soundfont/uzdoom.sf2 ${SOUNDFONT_DEST_DIR}/soundfonts/uzdoom.sf2
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different
-	${CMAKE_SOURCE_DIR}/fm_banks/GENMIDI.GS.wopl $<TARGET_FILE_DIR:zdoom>/fm_banks/GENMIDI.GS.wopl
+	${CMAKE_SOURCE_DIR}/fm_banks/GENMIDI.GS.wopl ${SOUNDFONT_DEST_DIR}/fm_banks/GENMIDI.GS.wopl
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different
-	${CMAKE_SOURCE_DIR}/fm_banks/gs-by-papiezak-and-sneakernets.wopn $<TARGET_FILE_DIR:zdoom>/fm_banks/gs-by-papiezak-and-sneakernets.wopn
+	${CMAKE_SOURCE_DIR}/fm_banks/gs-by-papiezak-and-sneakernets.wopn ${SOUNDFONT_DEST_DIR}/fm_banks/gs-by-papiezak-and-sneakernets.wopn
 )
 
 if ( NOT ZMUSIC_SYSTEM_INSTALL AND (NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS))


### PR DESCRIPTION
## Summary
- On macOS, the Cocoa backend sets `progdir` to `Contents/Resources/` (where `uzdoom.pk3` is found), but soundfont and FM bank files were being copied to `Contents/MacOS/` via `$<TARGET_FILE_DIR:zdoom>`
- This caused FluidSynth to fail with "Unable to find patch set uzdoom" and fall back to ADL, since `$PROGDIR/soundfonts/uzdoom.sf2` resolved to a nonexistent path
- Fixed by copying soundfonts and FM banks to `Contents/Resources/` on Apple, matching the PK3 destination and where `progdir` actually points

## Test plan
- [ ] Build on macOS and verify `Contents/Resources/soundfonts/uzdoom.sf2` exists in the .app bundle
- [ ] Launch UZDoom, select FluidSynth MIDI device, confirm music plays without "Unable to find patch set" error
- [ ] Verify non-Apple platforms are unaffected (soundfonts still go to `$<TARGET_FILE_DIR:zdoom>`)