### PR TITLE
Fix compiler warnings across src/

### DIFF
--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -1300,7 +1300,7 @@ static FString ReadVerificationError(TArrayView<uint8_t> stream)
 	}
 
 	TMap<FString, FString> files = {};
-	for (size_t i = 0u; i < fileSystem.GetNumWads(); ++i)
+	for (int i = 0; i < fileSystem.GetNumWads(); ++i)
 	{
 		if (!fileSystem.IsOptionalResource(i))
 		{

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -360,7 +360,7 @@ int FIWadManager::ScanIWAD (const char *iwad)
 
 	mLumpsFound.Resize(mIWadInfos.Size());
 
-	auto CheckFileName = [=](const char *name)
+	auto CheckFileName = [this](const char *name)
 	{
 		for (unsigned i = 0; i< mIWadInfos.Size(); i++)
 		{

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2060,12 +2060,24 @@ static void GetPackets()
 		int baseSequence = -1;
 		const int totalTics = NetBuffer[curByte++];
 		if (totalTics > 0)
-			baseSequence = (NetBuffer[curByte++] << 24) | (NetBuffer[curByte++] << 16) | (NetBuffer[curByte++] << 8) | NetBuffer[curByte++];
+		{
+			int b0 = NetBuffer[curByte++];
+			int b1 = NetBuffer[curByte++];
+			int b2 = NetBuffer[curByte++];
+			int b3 = NetBuffer[curByte++];
+			baseSequence = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+		}
 
 		int baseConsistency = -1;
 		const int ranTics = NetBuffer[curByte++];
 		if (ranTics > 0)
-			baseConsistency = (NetBuffer[curByte++] << 24) | (NetBuffer[curByte++] << 16) | (NetBuffer[curByte++] << 8) | NetBuffer[curByte++];
+		{
+			int b0 = NetBuffer[curByte++];
+			int b1 = NetBuffer[curByte++];
+			int b2 = NetBuffer[curByte++];
+			int b3 = NetBuffer[curByte++];
+			baseConsistency = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+		}
 
 		if (validID)
 		{
@@ -2085,7 +2097,11 @@ static void GetPackets()
 			if (clientNum == Net_Arbitrator)
 			{
 				if (consoleplayer != Net_Arbitrator)
-					pState.AverageLatency = (NetBuffer[curByte++] << 8) | NetBuffer[curByte++];
+				{
+					int hi = NetBuffer[curByte++];
+					int lo = NetBuffer[curByte++];
+					pState.AverageLatency = (hi << 8) | lo;
+				}
 				else
 					curByte += 2;
 			}
@@ -2101,7 +2117,9 @@ static void GetPackets()
 			for (int r = 0; r < ranTics; ++r)
 			{
 				int ofs = NetBuffer[curByte++];
-				consistencies.Insert(ofs, (NetBuffer[curByte++] << 8) | NetBuffer[curByte++]);
+				int hi = NetBuffer[curByte++];
+				int lo = NetBuffer[curByte++];
+				consistencies.Insert(ofs, (hi << 8) | lo);
 			}
 
 			for (size_t i = 0u; i < consistencies.Size(); ++i)
@@ -2680,7 +2698,7 @@ void NetUpdate(int tics)
 	int endSequence = newestTic;
 	int quitters = 0;
 	int quitNums[MAXPLAYERS];
-	int players = 1u;
+	unsigned players = 1u;
 	int maxCommands = MAXSENDTICS;
 	if (consoleplayer == Net_Arbitrator)
 	{
@@ -2972,7 +2990,7 @@ size_t Net_SetEngineInfo(uint8_t*& stream)
 	// Send over any loaded files to ensure their checksum is correct.
 	size_t numWads = 0u;
 	size_t bufferIndex = 7u;
-	for (size_t i = 0u; i < fileSystem.GetNumWads(); ++i)
+	for (int i = 0; i < fileSystem.GetNumWads(); ++i)
 	{
 		if (fileSystem.IsOptionalResource(i))
 			continue;
@@ -2997,7 +3015,7 @@ FVerificationError Net_VerifyEngine(uint8_t*& stream, size_t& offset)
 
 	TArray<FString> crcs = {};
 	TArray<FString> names = {};
-	for (size_t i = 0u; i < fileSystem.GetNumWads(); ++i)
+	for (int i = 0; i < fileSystem.GetNumWads(); ++i)
 	{
 		if (!fileSystem.IsOptionalResource(i))
 		{
@@ -3169,7 +3187,7 @@ bool D_CheckNetGame()
 		ClientStates[client].LastPacketReceivedTime = startTime;
 	}
 
-	if (MaxClients > 1u)
+	if ((unsigned)MaxClients > 1u)
 	{
 		if (dedicatedServer)
 			Printf("Dedicated server hosting %d players\n", MaxClients);
@@ -4944,10 +4962,10 @@ CCMD(kick)
 	}
 
 	TArray<int> cNums = {};
-	for (size_t i = 1u; i < argv.argc(); ++i)
+	for (int i = 1; i < argv.argc(); ++i)
 	{
 		int cNum = -1;
-		if (!C_IsValidInt(argv[i], cNum) || cNum < 0 || cNum >= MAXPLAYERS)
+		if (!C_IsValidInt(argv[i], cNum) || cNum < 0 || (size_t)cNum >= MAXPLAYERS)
 			Printf("Bad client number %s\n", argv[i]);
 		else if (cNum != consoleplayer && cNums.Find(cNum) >= cNums.Size())
 			cNums.Push(cNum);
@@ -4982,10 +5000,10 @@ CCMD(mute)
 	}
 
 	TArray<int> pNums = {};
-	for (size_t i = 1u; i < argv.argc(); ++i)
+	for (int i = 1; i < argv.argc(); ++i)
 	{
 		int pNum = -1;
-		if (!C_IsValidInt(argv[i], pNum) || pNum < 0 || pNum >= MAXPLAYERS)
+		if (!C_IsValidInt(argv[i], pNum) || pNum < 0 || (size_t)pNum >= MAXPLAYERS)
 			Printf("Bad player number %s\n", argv[i]);
 		else if (pNum != consoleplayer && pNums.Find(pNum) >= pNums.Size())
 			pNums.Push(pNum);
@@ -5013,9 +5031,9 @@ CCMD(muteall)
 		return;
 	}
 
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (size_t i = 0; i < MAXPLAYERS; ++i)
 	{
-		if (playeringame[i] && i != consoleplayer)
+		if (playeringame[i] && i != (size_t)consoleplayer)
 			MutedClients |= (uint64_t)1u << i;
 	}
 }
@@ -5057,10 +5075,10 @@ CCMD(unmute)
 	}
 
 	TArray<int> pNums = {};
-	for (size_t i = 1u; i < argv.argc(); ++i)
+	for (int i = 1; i < argv.argc(); ++i)
 	{
 		int pNum = -1;
-		if (!C_IsValidInt(argv[i], pNum) || pNum < 0 || pNum >= MAXPLAYERS)
+		if (!C_IsValidInt(argv[i], pNum) || pNum < 0 || (size_t)pNum >= MAXPLAYERS)
 			Printf("Bad player number %s\n", argv[i]);
 		else if (pNum != consoleplayer && pNums.Find(pNum) >= pNums.Size())
 			pNums.Push(pNum);
@@ -5155,10 +5173,10 @@ CCMD(addsettingscontrollers)
 	}
 
 	TArray<int> cNums = {};
-	for (size_t i = 1u; i < argv.argc(); ++i)
+	for (int i = 1; i < argv.argc(); ++i)
 	{
 		int cNum = -1;
-		if (!C_IsValidInt(argv[i], cNum) || cNum < 0 || cNum >= MAXPLAYERS)
+		if (!C_IsValidInt(argv[i], cNum) || cNum < 0 || (size_t)cNum >= MAXPLAYERS)
 			Printf("Bad client number %s\n", argv[i]);
 		else if (cNum != Net_Arbitrator && cNums.Find(cNum) >= cNums.Size())
 			cNums.Push(cNum);
@@ -5182,10 +5200,10 @@ CCMD(removesettingscontrollers)
 	}
 
 	TArray<int> cNums = {};
-	for (size_t i = 1u; i < argv.argc(); ++i)
+	for (int i = 1; i < argv.argc(); ++i)
 	{
 		int cNum = -1;
-		if (!C_IsValidInt(argv[i], cNum) || cNum < 0 || cNum >= MAXPLAYERS)
+		if (!C_IsValidInt(argv[i], cNum) || cNum < 0 || (size_t)cNum >= MAXPLAYERS)
 			Printf("Bad player number %s\n", argv[i]);
 		else if (cNum != Net_Arbitrator && cNums.Find(cNum) >= cNums.Size())
 			cNums.Push(cNum);

--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -740,7 +740,7 @@ static int namesortfunc(const void *a, const void *b)
 FString D_GetUserInfoStrings(int pnum, bool compact)
 {
 	FString result;
-	if (pnum >= 0 && pnum < MAXPLAYERS)
+	if (pnum >= 0 && (size_t)pnum < MAXPLAYERS)
 	{
 		userinfo_t* info = &players[pnum].userinfo;
 		TArray<TMap<FName, FBaseCVar*>::Pair*> userinfo_pairs(info->CountUsed());
@@ -828,7 +828,7 @@ void D_ReadUserInfoStrings (int pnum, TArrayView<uint8_t>& stream, bool update)
 		qsort(&compact_names[0], compact_names.Size(), sizeof(FName), namesortfunc);
 	}
 
-	if (pnum < MAXPLAYERS)
+	if ((size_t)pnum < MAXPLAYERS)
 	{
 		for (breakpt = ptr; breakpt != NULL; ptr = breakpt + 1)
 		{
@@ -1045,7 +1045,7 @@ CCMD(playerinfo)
 		{
 			i = consoleplayer;
 		}
-		else if (!C_IsValidInt(argv[1], i) || i < 0 || i >= MAXPLAYERS)
+		else if (!C_IsValidInt(argv[1], i) || i < 0 || (size_t)i >= MAXPLAYERS)
 		{
 			Printf("Bad player number %s\n", argv[1]);
 			return;

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2140,7 +2140,7 @@ void G_DoMidgameJoin()
 		{
 			uppitch = downpitch = (int)maxviewpitch;
 		}
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (size_t i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (playeringame[i] && players[i].mo)
 			{
@@ -3138,7 +3138,7 @@ void G_DoPlayDemo (void)
 		}
 		size_t demolen = fr.GetLength();
 		demobuffer.Resize(demolen);
-		if (fr.Read(demobuffer.Data(), demolen) != demolen)
+		if (fr.Read(demobuffer.Data(), demolen) != (ptrdiff_t)demolen)
 		{
 			I_Error("Unable to read demo '%s'", defdemoname.GetChars());
 		}

--- a/src/gamedata/info.cpp
+++ b/src/gamedata/info.cpp
@@ -118,7 +118,7 @@ void FState::SetAction(const char *name)
 
 void FState::CheckCallerType(AActor *self, AActor *stateowner)
 {
-	auto CheckType = [=](AActor *check, PType *requiredType)
+	auto CheckType = [this](AActor *check, PType *requiredType)
 	{
 		// This should really never happen. Any valid action function must have actor pointers here.
 		if (!requiredType->isObjectPointer())

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -4588,7 +4588,7 @@ int DLevelScript::GetPlayerInput(int playernum, int inputnum)
 		}
 		p = activator->player;
 	}
-	else if (playernum >= MAXPLAYERS || !Level->PlayerInGame(playernum))
+	else if ((size_t)playernum >= MAXPLAYERS || !Level->PlayerInGame(playernum))
 	{
 		return 0;
 	}
@@ -5524,7 +5524,7 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 		case ACSF_GetAirSupply:
 			MIN_ARG_COUNT(1);
 		{
-			if (args[0] < 0 || args[0] >= MAXPLAYERS || !Level->PlayerInGame(args[0]))
+			if (args[0] < 0 || (size_t)args[0] >= MAXPLAYERS || !Level->PlayerInGame(args[0]))
 			{
 				return 0;
 			}
@@ -5537,7 +5537,7 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 		case ACSF_SetAirSupply:
 			MIN_ARG_COUNT(2);
 		{
-			if (args[0] < 0 || args[0] >= MAXPLAYERS || !Level->PlayerInGame(args[0]))
+			if (args[0] < 0 || (size_t)args[0] >= MAXPLAYERS || !Level->PlayerInGame(args[0]))
 			{
 				return 0;
 			}
@@ -5560,7 +5560,7 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 		case ACSF_GetArmorType:
 			MIN_ARG_COUNT(2);
 		{
-			if (args[1] < 0 || args[1] >= MAXPLAYERS || !Level->PlayerInGame(args[1]))
+			if (args[1] < 0 || (size_t)args[1] >= MAXPLAYERS || !Level->PlayerInGame(args[1]))
 			{
 				return 0;
 			}
@@ -9849,7 +9849,7 @@ scriptwait:
 			break;
 
 		case PCD_PLAYERINGAME:
-			if (STACK(1) < 0 || STACK(1) >= MAXPLAYERS)
+			if (STACK(1) < 0 || (size_t)STACK(1) >= MAXPLAYERS)
 			{
 				STACK(1) = false;
 			}
@@ -9860,7 +9860,7 @@ scriptwait:
 			break;
 
 		case PCD_PLAYERISBOT:
-			if (STACK(1) < 0 || STACK(1) >= MAXPLAYERS || !Level->PlayerInGame(STACK(1)))
+			if (STACK(1) < 0 || (size_t)STACK(1) >= MAXPLAYERS || !Level->PlayerInGame(STACK(1)))
 			{
 				STACK(1) = false;
 			}
@@ -10059,7 +10059,7 @@ scriptwait:
 			break;
 
 		case PCD_PLAYERCLASS:		// [GRB]
-			if (STACK(1) < 0 || STACK(1) >= MAXPLAYERS || !Level->PlayerInGame(STACK(1)))
+			if (STACK(1) < 0 || (size_t)STACK(1) >= MAXPLAYERS || !Level->PlayerInGame(STACK(1)))
 			{
 				STACK(1) = -1;
 			}
@@ -10070,7 +10070,7 @@ scriptwait:
 			break;
 
 		case PCD_GETPLAYERINFO:		// [GRB]
-			if (STACK(2) < 0 || STACK(2) >= MAXPLAYERS || !Level->PlayerInGame(STACK(2)))
+			if (STACK(2) < 0 || (size_t)STACK(2) >= MAXPLAYERS || !Level->PlayerInGame(STACK(2)))
 			{
 				STACK(2) = -1;
 			}

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -103,7 +103,7 @@ static const struct ColorList {
 static void FreeParticle(FLevelLocals* Level, particle_t* particle)
 {
 	auto prev = particle->tprev == NO_PARTICLE? nullptr : &Level->Particles[particle->tprev];
-	int pindex = (int)(particle - Level->Particles.Data());
+	uint32_t pindex = (uint32_t)(particle - Level->Particles.Data());
 	auto tnext = particle->tnext;
 	assert(!prev || (prev->tnext == pindex));
 	if (prev)

--- a/src/playsim/p_lnspec.cpp
+++ b/src/playsim/p_lnspec.cpp
@@ -2832,7 +2832,7 @@ FUNC(LS_ChangeCamera)
 	{
 		int i;
 
-		for (i = 0; i < MAXPLAYERS; i++)
+		for (i = 0; (size_t)i < MAXPLAYERS; i++)
 		{
 			if (!Level->PlayerInGame(i))
 				continue;
@@ -2982,7 +2982,7 @@ FUNC(LS_SetPlayerProperty)
 		{
 			int i;
 
-			for (i = 0; i < MAXPLAYERS; i++)
+			for (i = 0; (size_t)i < MAXPLAYERS; i++)
 			{
 				auto p = Level->Players[i];
 				if (!Level->PlayerInGame(i) || p->mo == nullptr)
@@ -3097,7 +3097,7 @@ FUNC(LS_SetPlayerProperty)
 			mask = CF_FROZEN | CF_TOTALLYFROZEN;
 		}
 
-		for (i = 0; i < MAXPLAYERS; i++)
+		for (i = 0; (size_t)i < MAXPLAYERS; i++)
 		{
 			if (!Level->PlayerInGame(i))
 				continue;
@@ -3338,7 +3338,7 @@ FUNC(LS_GlassBreak)
 		{ // Up stats and signal this mission is complete
 			if (it == NULL)
 			{
-				for (int i = 0; i < MAXPLAYERS; ++i)
+				for (size_t i = 0; i < MAXPLAYERS; ++i)
 				{
 					if (Level->PlayerInGame(i))
 					{

--- a/src/rendering/hwrenderer/scene/hw_drawlist.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawlist.cpp
@@ -609,7 +609,7 @@ SortNode * HWDrawList::SortSpriteList(SortNode * head)
 
 	sortspritelist.Clear();
 	for(count=0,n=head;n;n=n->next) sortspritelist.Push(n);
-	std::stable_sort(sortspritelist.begin(), sortspritelist.end(), [=](SortNode *a, SortNode *b)
+	std::stable_sort(sortspritelist.begin(), sortspritelist.end(), [this](SortNode *a, SortNode *b)
 	{
 		return CompareSprites(a, b) < 0;
 	});

--- a/src/rendering/swrenderer/scene/r_scene.cpp
+++ b/src/rendering/swrenderer/scene/r_scene.cpp
@@ -298,7 +298,7 @@ namespace swrenderer
 			std::unique_ptr<RenderThread> thread(new RenderThread(this, false));
 			auto renderthread = thread.get();
 			int start_run_id = run_id;
-			thread->thread = std::thread([=]()
+			thread->thread = std::thread([this, renderthread, start_run_id]()
 			{
 				int last_run_id = start_run_id;
 				while (true)

--- a/src/widgets/aboutpage.cpp
+++ b/src/widgets/aboutpage.cpp
@@ -75,7 +75,7 @@ AboutPage::AboutPage(LauncherWindow* launcher, const FStartupSelectionInfo& info
 	Text->SetReadOnly(true);
 	Notes->SetText(GStrings.GetString("PICKER_SHOWNOTES"));
 
-	Notes->OnClick = [=]()
+	Notes->OnClick = [this, launcher, info]()
 	{
 		if (!Launcher->Release)
 		{

--- a/src/widgets/errorwindow.cpp
+++ b/src/widgets/errorwindow.cpp
@@ -51,19 +51,19 @@ ErrorWindow::ErrorWindow(std::vector<uint8_t> initminidump) : Widget(nullptr, Wi
 
 	LogView = new LogViewer(this);
 	ClipboardButton = new PushButton(this);
-	ClipboardButton->OnClick = [=]() { OnClipboardButtonClicked(); };
+	ClipboardButton->OnClick = [this]() { OnClipboardButtonClicked(); };
 	ClipboardButton->SetText(GStrings.GetString("ACTION_COPYTOCLIPBOARD"));
 
 	if (minidump.empty())
 	{
 		RestartButton = new PushButton(this);
-		RestartButton->OnClick = [=]() { OnRestartButtonClicked(); };
+		RestartButton->OnClick = [this]() { OnRestartButtonClicked(); };
 		RestartButton->SetText(GStrings.GetString("ACTION_RESTART"));
 	}
 	else
 	{
 		SaveReportButton = new PushButton(this);
-		SaveReportButton->OnClick = [=]() { OnSaveReportButtonClicked(); };
+		SaveReportButton->OnClick = [this]() { OnSaveReportButtonClicked(); };
 		SaveReportButton->SetText(GStrings.GetString("ERRORMNU_SAVE"));
 	}
 
@@ -168,7 +168,7 @@ LogViewer::LogViewer(Widget* parent) : Widget(parent)
 	SetNoncontentSizes(8.0, 8.0, 3.0, 8.0);
 
 	scrollbar = new Scrollbar(this);
-	scrollbar->FuncScroll = [=]() { OnScrollbarScroll(); };
+	scrollbar->FuncScroll = [this]() { OnScrollbarScroll(); };
 }
 
 void LogViewer::SetText(const std::string& text, const std::string& log)

--- a/src/widgets/launcherbuttonbar.cpp
+++ b/src/widgets/launcherbuttonbar.cpp
@@ -25,8 +25,8 @@ LauncherButtonbar::LauncherButtonbar(LauncherWindow* parent) : Widget(parent)
 	PlayButton = new PushButton(this);
 	ExitButton = new PushButton(this);
 
-	PlayButton->OnClick = [=]() { OnPlayButtonClicked(); };
-	ExitButton->OnClick = [=]() { OnExitButtonClicked(); };
+	PlayButton->OnClick = [this]() { OnPlayButtonClicked(); };
+	ExitButton->OnClick = [this]() { OnExitButtonClicked(); };
 }
 
 void LauncherButtonbar::UpdateLanguage()

--- a/src/widgets/netstartwindow.cpp
+++ b/src/widgets/netstartwindow.cpp
@@ -182,7 +182,7 @@ NetStartWindow::NetStartWindow(bool host) : Widget(nullptr, WidgetType::Window)
 	MessageLabel->SetTextAlignment(TextLabelAlignment::Center);
 	ProgressLabel->SetTextAlignment(TextLabelAlignment::Center);
 
-	AbortButton->OnClick = [=]() { OnClose(); };
+	AbortButton->OnClick = [this]() { OnClose(); };
 	AbortButton->SetText(GStrings.GetString("ACTION_ABORT"));
 
 	if (host)
@@ -190,15 +190,15 @@ NetStartWindow::NetStartWindow(bool host) : Widget(nullptr, WidgetType::Window)
 		hosting = true;
 
 		ForceStartButton = new PushButton(this);
-		ForceStartButton->OnClick = [=]() { ForceStart(); };
+		ForceStartButton->OnClick = [this]() { ForceStart(); };
 		ForceStartButton->SetText(GStrings.GetString("ACTION_STARTGAME"));
 
 		KickButton = new PushButton(this);
-		KickButton->OnClick = [=]() { OnKick(); };
+		KickButton->OnClick = [this]() { OnKick(); };
 		KickButton->SetText(GStrings.GetString("ACTION_KICK"));
 
 		BanButton = new PushButton(this);
-		BanButton->OnClick = [=]() { OnBan(); };
+		BanButton->OnClick = [this]() { OnBan(); };
 		BanButton->SetText(GStrings.GetString("ACTION_BAN"));
 	}
 
@@ -206,7 +206,7 @@ NetStartWindow::NetStartWindow(bool host) : Widget(nullptr, WidgetType::Window)
 	LobbyWindow->SetColumnWidths({ 30.0, 30.0, 200.0, 50.0 });
 
 	CallbackTimer = new Timer(this);
-	CallbackTimer->FuncExpired = [=]() { OnCallbackTimerExpired(); };
+	CallbackTimer->FuncExpired = [this]() { OnCallbackTimerExpired(); };
 	CallbackTimer->Start(500);
 }
 

--- a/src/widgets/playgamepage.cpp
+++ b/src/widgets/playgamepage.cpp
@@ -63,7 +63,7 @@ PlayGamePage::PlayGamePage(LauncherWindow* launcher, const FStartupSelectionInfo
 		GamesList->ScrollToItem(info.DefaultIWAD);
 	}
 
-	GamesList->OnActivated = [=]() { OnGamesListActivated(); };
+	GamesList->OnActivated = [this]() { OnGamesListActivated(); };
 }
 
 void PlayGamePage::SetValues(FStartupSelectionInfo& info) const

--- a/src/widgets/settingspage.cpp
+++ b/src/widgets/settingspage.cpp
@@ -126,7 +126,7 @@ SettingsPage::SettingsPage(LauncherWindow* launcher, const FStartupSelectionInfo
 			LangList->SetSelectedItem(i);
 		++i;
 	}
-	LangList->OnChanged = [=](int i) { OnLanguageChanged(i); };
+	LangList->OnChanged = [this](int i) { OnLanguageChanged(i); };
 
 	ExtraWadFlags = 0;
 


### PR DESCRIPTION
## Summary
- Fix undefined behavior from unsequenced modifications to `curByte` in `d_net.cpp`
- Replace deprecated implicit `this` capture (`[=]`) with explicit captures in 16 lambdas
- Fix 22 signed/unsigned comparison warnings against `MAXPLAYERS` and `size_t`
- Fix `ptrdiff_t` vs `size_t` format mismatch in `g_game.cpp`
- Fix `uint32_t` vs `int` type mismatch for particle index in `p_effect.cpp`

17 files changed, zero compiler warnings remaining in `src/`.

## Test plan
- [x] Clean Release build passes with no source warnings
- [ ] Verify in-game: singleplayer, multiplayer, dedicated server
- [ ] Verify on other platforms (MSVC, Linux GCC/LLVM)