### PR TITLE
Rework dedicated late-join activation and ghost host sync

### DIFF
--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -197,6 +197,7 @@ extern void HandleMidgameStateChunkAck();
 extern void HandleMidgameStateComplete();
 extern void HandleMidgameStateReady();
 extern void HandleMidgameStateLoaded();
+extern void HandleMidgameStateActive();
 extern void HandleMidgameStateError();
 
 CUSTOM_CVAR(String, net_password, "", CVAR_IGNORE)
@@ -957,6 +958,10 @@ void HandleIncomingConnection()
 	case PRE_MIDGAME_STATE_LOADED:
 		if (RemoteClient >= 0)
 			HandleMidgameStateLoaded();
+		return;
+	case PRE_MIDGAME_STATE_ACTIVE:
+		if (RemoteClient >= 0)
+			HandleMidgameStateActive();
 		return;
 	case PRE_MIDGAME_STATE_ERROR:
 		if (RemoteClient >= 0)

--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -160,6 +160,7 @@ enum ENetConnectType : uint8_t
 	PRE_MIDGAME_STATE_COMPLETE,	// Host -> Joiner: all chunks sent
 	PRE_MIDGAME_STATE_READY,	// Joiner -> Host: initialized, ready for state
 	PRE_MIDGAME_STATE_LOADED,	// Joiner -> Host: snapshot loaded successfully
+	PRE_MIDGAME_STATE_ACTIVE,	// Joiner -> Host: pre-activation sync processed locally
 	PRE_MIDGAME_STATE_ERROR,	// Joiner -> Host: error, abort transfer
 };
 

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1107,9 +1107,10 @@ void D_Display ()
 	if (nodrawers || screen == NULL)
 		return; 				// for comparative timing / profiling
 
-	// Mid-game joiner: don't render until DEM_MIDGAMESPAWN fires and spawns our actor.
-	if (consoleplayer < 0 || !playeringame[consoleplayer])
+	if (consoleplayer < 0)
 		return;
+
+	const bool canRenderLevelView = playeringame[consoleplayer] || G_CanRenderMidgameJoinView();
 
 	if (!AppActive && !setmodeneeded && !vid_activeinbackground)
 	{
@@ -1123,7 +1124,7 @@ void D_Display ()
 
 	r_renderercaps = GetCaps(); // [SP] Get the current capabilities of the renderer
 
-	if (players[consoleplayer].camera == NULL)
+	if (players[consoleplayer].camera == NULL && playeringame[consoleplayer])
 	{
 		players[consoleplayer].camera = players[consoleplayer].mo;
 	}
@@ -1214,55 +1215,63 @@ void D_Display ()
 		// [ZZ] execute event hook that we just started the frame
 		//E_RenderFrame();
 		//
-
-		D_Render([&]()
+		if (gamestate != GS_LEVEL || canRenderLevelView)
 		{
-			viewsec = RenderView(&players[consoleplayer]);
-		}, true);
+			D_Render([&]()
+			{
+				viewsec = RenderView(&players[consoleplayer]);
+			}, true);
+		}
 
 		twod->Begin(screen->GetWidth(), screen->GetHeight());
-		if (!hud_toggled)
+		if (gamestate != GS_LEVEL || canRenderLevelView)
 		{
-			V_DrawBlend(viewsec);
-			if (automapactive)
+			if (!hud_toggled)
 			{
-				primaryLevel->automap->Drawer ((hud_althud && viewheight == SCREENHEIGHT) ? viewheight : StatusBar->GetTopOfStatusbar());
-			}
-
-			// for timing the statusbar code.
-			//cycle_t stb;
-			//stb.Reset();
-			//stb.Clock();
-			if (!automapactive || viewactive)
-			{
-				StatusBar->RefreshViewBorder ();
-			}
-			if (hud_althud && viewheight == SCREENHEIGHT && screenblocks > 10)
-			{
-				StatusBar->DrawBottomStuff (HUD_AltHud);
-				if (DrawFSHUD || automapactive) StatusBar->DrawAltHUD();
-				if (players[consoleplayer].camera && players[consoleplayer].camera->player && !automapactive)
+				V_DrawBlend(viewsec);
+				if (automapactive)
 				{
-					StatusBar->DrawCrosshair(vp.TicFrac);
+					primaryLevel->automap->Drawer ((hud_althud && viewheight == SCREENHEIGHT) ? viewheight : StatusBar->GetTopOfStatusbar());
 				}
-				StatusBar->CallDraw (HUD_AltHud, vp.TicFrac);
-				StatusBar->DrawTopStuff (HUD_AltHud);
+
+				if (gamestate != GS_LEVEL || playeringame[consoleplayer])
+				{
+					// for timing the statusbar code.
+					//cycle_t stb;
+					//stb.Reset();
+					//stb.Clock();
+					if (!automapactive || viewactive)
+					{
+						StatusBar->RefreshViewBorder ();
+					}
+					if (hud_althud && viewheight == SCREENHEIGHT && screenblocks > 10)
+					{
+						StatusBar->DrawBottomStuff (HUD_AltHud);
+						if (DrawFSHUD || automapactive) StatusBar->DrawAltHUD();
+						if (players[consoleplayer].camera && players[consoleplayer].camera->player && !automapactive)
+						{
+							StatusBar->DrawCrosshair(vp.TicFrac);
+						}
+						StatusBar->CallDraw (HUD_AltHud, vp.TicFrac);
+						StatusBar->DrawTopStuff (HUD_AltHud);
+					}
+					else if (viewheight == SCREENHEIGHT && viewactive && screenblocks > 10)
+					{
+						EHudState state = DrawFSHUD ? HUD_Fullscreen : HUD_None;
+						StatusBar->DrawBottomStuff (state);
+						StatusBar->CallDraw (state, vp.TicFrac);
+						StatusBar->DrawTopStuff (state);
+					}
+					else
+					{
+						StatusBar->DrawBottomStuff (HUD_StatusBar);
+						StatusBar->CallDraw (HUD_StatusBar, vp.TicFrac);
+						StatusBar->DrawTopStuff (HUD_StatusBar);
+					}
+					//stb.Unclock();
+					//Printf("Stbar = %f\n", stb.TimeMS());
+				}
 			}
-			else if (viewheight == SCREENHEIGHT && viewactive && screenblocks > 10)
-			{
-				EHudState state = DrawFSHUD ? HUD_Fullscreen : HUD_None;
-				StatusBar->DrawBottomStuff (state);
-				StatusBar->CallDraw (state, vp.TicFrac);
-				StatusBar->DrawTopStuff (state);
-			}
-			else
-			{
-				StatusBar->DrawBottomStuff (HUD_StatusBar);
-				StatusBar->CallDraw (HUD_StatusBar, vp.TicFrac);
-				StatusBar->DrawTopStuff (HUD_StatusBar);
-			}
-			//stb.Unclock();
-			//Printf("Stbar = %f\n", stb.TimeMS());
 		}
 	}
 	else
@@ -2998,7 +3007,7 @@ static bool System_DispatchEvent(event_t* ev)
 {
 	shiftState.AddEvent(ev);
 
-	if (ev->type == EV_Mouse && gamestate == GS_LEVEL && menuactive == MENU_Off && ConsoleState != c_down && ConsoleState != c_falling && !primaryLevel->localEventManager->Responder(ev) && !paused)
+	if (ev->type == EV_Mouse && gamestate == GS_LEVEL && menuactive == MENU_Off && ConsoleState != c_down && ConsoleState != c_falling && !primaryLevel->localEventManager->Responder(ev) && !paused && !Net_ShouldSuppressMidgameJoinInput())
 	{
 		if (buttonMap.ButtonDown(Button_Mlook) || freelook)
 		{

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -57,6 +57,7 @@
 #include "savegamemanager.h"
 #include "sbar.h"
 #include "screenjob.h"
+#include "serializer.h"
 #include "version.h"
 #include "vm.h"
 
@@ -775,17 +776,6 @@ static void ClientConnecting(int client)
 	state.Flags = CF_JOINING | CF_AWAITING_STATE;
 	state.LastPacketReceivedTime = I_msTime();
 
-	// Notify all other clients that a new player is joining.
-	uint8_t buf[4];
-	buf[0] = NCMD_SETUP;
-	buf[1] = PRE_MIDGAME_PLAYER_JOIN;
-	buf[2] = static_cast<uint8_t>(client);
-	for (auto c : NetworkClients)
-	{
-		if (c != consoleplayer && c != client)
-			I_SendSetupPacket(c, buf, 3);
-	}
-
 	Printf("Client %d is joining mid-game\n", client);
 }
 
@@ -1108,8 +1098,25 @@ static FStateTransferSend PendingStateTransfer;
 FStateTransferRecv IncomingStateTransfer;
 static void AbortStateTransfer();
 static void BeginStateTransfer(int client);
+static bool IsMapLoaded();
 void Net_SetupUserInfo();
 static uint32_t StaticSumSeeds();
+
+static bool CanAcceptMidgameJoinNow()
+{
+	return gamestate == GS_LEVEL
+		&& IsMapLoaded()
+		&& gameaction == ga_nothing
+		&& LevelStartStatus == LST_READY
+		&& !bMigrating
+		&& !PendingStateTransfer.active;
+}
+
+static void RejectIncomingMidgameJoin(EMidgameRejectReason reason)
+{
+	uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, static_cast<uint8_t>(reason) };
+	I_SendSetupPacketToAddress(buf, 3);
+}
 
 
 // Host receives: an unknown client wants to join mid-game.
@@ -1123,8 +1130,16 @@ void HandleMidgameConnect()
 	// lockstep desync issues with 3+ players.
 	if (!dedicatedServer && !net_allowjoin)
 	{
-		uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, REJECT_DISABLED };
-		I_SendSetupPacketToAddress(buf, 3);
+		RejectIncomingMidgameJoin(REJECT_DISABLED);
+		return;
+	}
+
+	// Only allow late joins while the host is safely inside active level play.
+	// Everything else should be treated as a transient retry so we do not race
+	// level transitions or partially initialize a join that cannot complete.
+	if (!CanAcceptMidgameJoinNow())
+	{
+		RejectIncomingMidgameJoin(REJECT_IN_TRANSITION);
 		return;
 	}
 
@@ -1132,26 +1147,18 @@ void HandleMidgameConnect()
 	// transferring state or still initializing (V_Init2/shaders) before
 	// requesting state. Without this, multiple clients can be accepted and
 	// all but the first deadlock when their STATE_READY is silently dropped.
-	if (bMigrating || PendingStateTransfer.active)
-	{
-		uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, REJECT_IN_TRANSITION };
-		I_SendSetupPacketToAddress(buf, 3);
-		return;
-	}
 	for (auto c : NetworkClients)
 	{
 		if (ClientStates[c].Flags & (CF_JOINING | CF_AWAITING_STATE))
 		{
-			uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, REJECT_IN_TRANSITION };
-			I_SendSetupPacketToAddress(buf, 3);
+			RejectIncomingMidgameJoin(REJECT_IN_TRANSITION);
 			return;
 		}
 	}
-
+	
 	if (I_IsAddressBanned())
 	{
-		uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, REJECT_BANNED };
-		I_SendSetupPacketToAddress(buf, 3);
+		RejectIncomingMidgameJoin(REJECT_BANNED);
 		return;
 	}
 
@@ -1168,8 +1175,7 @@ void HandleMidgameConnect()
 
 	if (freeSlot < 0)
 	{
-		uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, REJECT_FULL };
-		I_SendSetupPacketToAddress(buf, 3);
+		RejectIncomingMidgameJoin(REJECT_FULL);
 		return;
 	}
 
@@ -1179,8 +1185,7 @@ void HandleMidgameConnect()
 	FVerificationError error = Net_VerifyEngine(engineInfo, passwordOffset);
 	if (error.Error != FVerificationError::VE_NONE)
 	{
-		uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, REJECT_VERIFICATION };
-		I_SendSetupPacketToAddress(buf, 3);
+		RejectIncomingMidgameJoin(REJECT_VERIFICATION);
 		return;
 	}
 
@@ -1190,8 +1195,7 @@ void HandleMidgameConnect()
 		|| memchr(&NetBuffer[2u + passwordOffset], '\0', NetBufferLength - 2u - passwordOffset) == nullptr
 		|| strcmp(net_password, (const char*)&NetBuffer[2u + passwordOffset])))
 	{
-		uint8_t buf[3] = { NCMD_SETUP, PRE_MIDGAME_REJECT, REJECT_PASSWORD };
-		I_SendSetupPacketToAddress(buf, 3);
+		RejectIncomingMidgameJoin(REJECT_PASSWORD);
 		return;
 	}
 
@@ -1413,21 +1417,29 @@ static void BeginStateTransfer(int client)
 		return;
 	}
 
-	// Serialize the full RNG state. The joiner must have the exact same RNG
-	// state as the server at the snapshot gametic so tics between snapshot
-	// and DEM_MIDGAMESPAWN produce identical results on all nodes.
-	TArray<uint8_t> rngData;
-	FRandom::StaticWriteRNGBinary(rngData);
+	FSerializer globals;
+	if (!globals.OpenWriter(false))
+	{
+		Printf("BeginStateTransfer: failed to serialize globals\n");
+		if (playeringame[consoleplayer] && !dedicatedServer)
+			P_PredictClient();
+		return;
+	}
+	G_SerializeMidgameGlobalsPreInit(globals);
+	G_SerializeMidgameGlobalsPostInit(globals);
+	unsigned globalsSize = 0;
+	const char* globalsData = globals.GetOutput(&globalsSize);
 
-	// Build transfer buffer: [globals (RNG state)] + [16-byte snapshot header] + [compressed snapshot]
+	// Build transfer buffer: [globals JSON blob] + [16-byte snapshot header] + [compressed snapshot]
 	const auto& snap = info->Snapshot;
 	const size_t snapshotHeaderSize = 16;
 	const size_t snapshotSize = snap.mCompressedSize;
-	xfer.globalsSize = rngData.Size();
+	xfer.globalsSize = globalsSize;
 	xfer.data.Resize(xfer.globalsSize + snapshotHeaderSize + snapshotSize);
 
-	// Copy globals (RNG state) first.
-	memcpy(xfer.data.Data(), rngData.Data(), xfer.globalsSize);
+	// Copy globals first.
+	if (xfer.globalsSize > 0)
+		memcpy(xfer.data.Data(), globalsData, xfer.globalsSize);
 
 	// Then the snapshot header + data.
 	uint8_t* hdr = xfer.data.Data() + xfer.globalsSize;
@@ -1742,8 +1754,14 @@ void HandleMidgameStateReady()
 		|| !(ClientStates[joinerSlot].Flags & CF_AWAITING_STATE))
 		return;
 
-	if (PendingStateTransfer.active)
-		return; // Already transferring state to someone.
+	if (!CanAcceptMidgameJoinNow())
+	{
+		Printf("Client %d became ready while the host was transitioning, aborting join\n", joinerSlot);
+		SendSetupPacketToClient(joinerSlot, PRE_MIDGAME_STATE_ERROR);
+		ClientStates[joinerSlot].Flags &= ~(CF_JOINING | CF_AWAITING_STATE);
+		DisconnectClient(joinerSlot);
+		return;
+	}
 
 	if (NetBufferLength > 2)
 	{

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <stddef.h>
+#include <stdio.h>
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -85,6 +86,7 @@ extern FString	savegamefile;
 extern bool AppActive;
 
 void P_ClearLevelInterpolation();
+static bool IsMapLoaded();
 
 // Big-endian read/write helpers for network packet serialization.
 static inline void WriteBE32(uint8_t* p, uint32_t v)
@@ -257,6 +259,69 @@ CUSTOM_CVAR(Int, cl_debugprediction, 0, CVAR_CHEAT)
 	else if (self > BACKUPTICS - 1)
 		self = BACKUPTICS - 1;
 }
+CVAR(Bool, net_dedicatedhibernate, true, CVAR_SERVERINFO | CVAR_NOSAVE)
+
+bool Net_IsGhostPlayer(int player)
+{
+	return (dedicatedServer || hostIsDedicated) && player == 0;
+}
+
+static bool IsDedicatedControlStream(int player)
+{
+	return Net_IsGhostPlayer(player);
+}
+
+static bool IsRealGameplayPlayer(int player)
+{
+	return player >= 0 && player < (int)MAXPLAYERS && playeringame[player] && !Net_IsGhostPlayer(player);
+}
+
+static int CountRealGameplayPlayers()
+{
+	int total = 0;
+	for (int i = 0; i < (int)MAXPLAYERS; ++i)
+	{
+		if (IsRealGameplayPlayer(i))
+			++total;
+	}
+
+	return total;
+}
+
+static int CountNonGhostNetworkClients(bool includeQuitters)
+{
+	int total = 0;
+	for (auto client : NetworkClients)
+	{
+		if (Net_IsGhostPlayer(client))
+			continue;
+		if (!includeQuitters && (ClientStates[client].Flags & CF_QUIT))
+			continue;
+		++total;
+	}
+
+	return total;
+}
+
+static bool HasNonGhostNetworkClient()
+{
+	return CountNonGhostNetworkClients(false) > 0;
+}
+
+static bool ShouldHibernateDedicatedServer()
+{
+	return dedicatedServer
+		&& net_dedicatedhibernate
+		&& !demoplayback
+		&& gamestate == GS_LEVEL
+		&& gameaction == ga_nothing
+		&& LevelStartStatus == LST_READY
+		&& IsMapLoaded()
+		&& !HasNonGhostNetworkClient()
+		&& CountRealGameplayPlayers() == 0;
+}
+
+static void ResetNetLagHistories();
 
 // Used to write out all network events that occured leading up to the next tick.
 static struct NetEventData
@@ -469,6 +534,7 @@ void Net_ClearBuffers()
 
 	FullLatencyCycle = MAXSENDTICS * 3;
 	LastLatencyUpdate = 0;
+	ResetNetLagHistories();
 
 	playeringame[0] = true;
 	NetworkClients += 0;
@@ -490,7 +556,7 @@ bool Net_IsPlayerReady(int player)
 	}
 
 	// Ghost player on dedicated servers is always ready (no human to press buttons).
-	if ((dedicatedServer || hostIsDedicated) && player == 0)
+	if (Net_IsGhostPlayer(player))
 		return true;
 
 	return players[player].Bot != nullptr || (CutsceneReady & ((uint64_t)1u << player));
@@ -535,17 +601,25 @@ bool Net_CheckCutsceneReady()
 
 	uint64_t mask = 0u;
 	int totalReady = 0;
+	int totalPlayers = 0;
 	// Bots will be automatically assumed to be ready, so we don't include them.
 	for (auto client : NetworkClients)
 	{
+		if (Net_IsGhostPlayer(client))
+			continue;
+
 		mask |= (uint64_t)1u << client;
 		totalReady += Net_IsPlayerReady(client);
+		++totalPlayers;
 	}
+
+	if (totalPlayers <= 0)
+		return false;
 
 	if ((CutsceneReady & mask) == mask)
 		return true;
 
-	if ((float)totalReady / NetworkClients.Size() < net_cutscenereadypercent)
+	if ((float)totalReady / totalPlayers < net_cutscenereadypercent)
 		return false;
 
 	if (CutsceneCountdown <= 0)
@@ -610,7 +684,7 @@ void Net_ResetCommands(bool midTic)
 	for (auto client : NetworkClients)
 	{
 		auto& state = ClientStates[client];
-		state.Flags &= (CF_QUIT | CF_JOINING | CF_AWAITING_STATE);
+		state.Flags &= (CF_QUIT | CF_JOINING | CF_AWAITING_STATE | CF_AWAITING_ACTIVE);
 		state.StabilityBuffer = 0u;
 		state.CurrentSequence = min<int>(state.CurrentSequence, tic);
 		state.SequenceAck = min<int>(state.SequenceAck, tic);
@@ -768,11 +842,13 @@ static void ClientConnecting(int client)
 	// Initialize network state for the joining client.
 	auto& state = ClientStates[client];
 	memset(&state, 0, sizeof(FClientNetState));
-	state.CurrentSequence = gametic / TicDup;
-	state.SequenceAck = gametic / TicDup;
-	state.CurrentNetConsistency = CurrentConsistency;
-	state.ConsistencyAck = CurrentConsistency;
-	state.LastVerifiedConsistency = CurrentConsistency;
+	const int lastSeq = max(gametic / TicDup - 1, -1);
+	const int lastCon = max(CurrentConsistency - 1, -1);
+	state.CurrentSequence = lastSeq;
+	state.SequenceAck = lastSeq;
+	state.CurrentNetConsistency = lastCon;
+	state.ConsistencyAck = lastCon;
+	state.LastVerifiedConsistency = lastCon;
 	state.Flags = CF_JOINING | CF_AWAITING_STATE;
 	state.LastPacketReceivedTime = I_msTime();
 
@@ -1098,6 +1174,311 @@ static FStateTransferSend PendingStateTransfer;
 FStateTransferRecv IncomingStateTransfer;
 static void AbortStateTransfer();
 static void BeginStateTransfer(int client);
+static int16_t CalculateConsistency(int client, uint32_t seed);
+static void ResetNetLagHistories();
+static int16_t CalculatePendingJoinConsistency(int client, uint32_t seed);
+
+static bool IsWaitingForMidgameSpawn()
+{
+	return consoleplayer >= 0
+		&& consoleplayer != Net_Arbitrator
+		&& !playeringame[consoleplayer]
+		&& IncomingStateTransfer.loadedSent
+		&& !IncomingStateTransfer.activeSent;
+}
+
+static bool IsAwaitingMidgameActivation()
+{
+	return consoleplayer >= 0
+		&& consoleplayer != Net_Arbitrator
+		&& !playeringame[consoleplayer]
+		&& IncomingStateTransfer.activeSent;
+}
+
+constexpr int NETLAG_HISTORY_SAMPLES = 350;
+
+struct FNetLagHistory
+{
+	int Values[NETLAG_HISTORY_SAMPLES] = {};
+	int Index = 0;
+	int Count = 0;
+	int Sum = 0;
+	int Max = 0;
+
+	void Reset()
+	{
+		memset(Values, 0, sizeof(Values));
+		Index = Count = Sum = Max = 0;
+	}
+
+	void Push(int value)
+	{
+		value = max(value, 0);
+		if (Count < NETLAG_HISTORY_SAMPLES)
+		{
+			Values[Index] = value;
+			Sum += value;
+			Max = max(Max, value);
+			Index = (Index + 1) % NETLAG_HISTORY_SAMPLES;
+			++Count;
+			return;
+		}
+
+		const int old = Values[Index];
+		Values[Index] = value;
+		Sum += value - old;
+		Index = (Index + 1) % NETLAG_HISTORY_SAMPLES;
+
+		if (value >= Max)
+		{
+			Max = value;
+		}
+		else if (old == Max)
+		{
+			Max = 0;
+			for (int i = 0; i < Count; ++i)
+				Max = max(Max, Values[i]);
+		}
+	}
+
+	int Current() const
+	{
+		if (Count <= 0)
+			return 0;
+		const int cur = (Index + NETLAG_HISTORY_SAMPLES - 1) % NETLAG_HISTORY_SAMPLES;
+		return Values[cur];
+	}
+
+	int Average() const
+	{
+		return Count > 0 ? (Sum + Count / 2) / Count : 0;
+	}
+};
+
+static FNetLagHistory LocalInputLagHistory = {};
+static FNetLagHistory StreamBehindHistory[MAXPLAYERS] = {};
+static int LastLagHistorySample = INT_MIN;
+static int LastLagDumpSecond = INT_MIN;
+
+CVAR(Bool, net_lagdump, false, CVAR_NOSAVE)
+
+static void ResetNetLagDumpFile();
+static void DumpNetLagHistoriesIfNeeded();
+
+static int SeqTicsToMs(int tics)
+{
+	return min<int>(xs_RoundToInt(tics * TicDup * 1000.0 / TICRATE), 9999);
+}
+
+static FString GetNetLagDumpPath()
+{
+	if (consoleplayer == Net_Arbitrator)
+		return "/tmp/uzdoom-netlag-host.log";
+	if (consoleplayer >= 0 && consoleplayer < (int)MAXPLAYERS)
+		return FStringf("/tmp/uzdoom-netlag-client%d.log", consoleplayer + 1);
+	return "/tmp/uzdoom-netlag-client-unknown.log";
+}
+
+static bool IsTrackableClientForLagStats(int client)
+{
+	if (client < 0 || client >= (int)MAXPLAYERS || !NetworkClients.InGame(client))
+		return false;
+	if (ClientStates[client].Flags & (CF_JOINING | CF_AWAITING_STATE | CF_QUIT))
+		return false;
+	return true;
+}
+
+static int GetDisplayedClientSequenceForLagStats(int client, int newestSequence)
+{
+	int seq = ClientStates[client].CurrentSequence;
+	if (consoleplayer != Net_Arbitrator && client == consoleplayer)
+		seq = max(seq, newestSequence - 1);
+	return seq;
+}
+
+static void ResetNetLagHistories()
+{
+	LocalInputLagHistory.Reset();
+	for (auto& history : StreamBehindHistory)
+		history.Reset();
+	LastLagHistorySample = INT_MIN;
+	LastLagDumpSecond = INT_MIN;
+	if (net_lagdump)
+		ResetNetLagDumpFile();
+}
+
+static void ResetNetLagDumpFile()
+{
+	const FString path = GetNetLagDumpPath();
+	if (FILE* file = fopen(path.GetChars(), "w"))
+	{
+		fprintf(file, "# UZDoom network lag dump\n");
+		fclose(file);
+	}
+}
+
+static void SampleNetLagHistories()
+{
+	if (!netgame || demoplayback || LevelStartStatus != LST_READY)
+		return;
+
+	const int sampleSeq = gametic / TicDup;
+	if (sampleSeq == LastLagHistorySample)
+		return;
+	LastLagHistorySample = sampleSeq;
+
+	LocalInputLagHistory.Push(max<int>((ClientTic - gametic) / TicDup, 0));
+
+	const int newestSequence = ClientTic / TicDup;
+	for (int client = 0; client < (int)MAXPLAYERS; ++client)
+	{
+		if (!IsTrackableClientForLagStats(client))
+		{
+			if (!NetworkClients.InGame(client))
+				StreamBehindHistory[client].Reset();
+			continue;
+		}
+
+		const int seq = GetDisplayedClientSequenceForLagStats(client, newestSequence);
+		StreamBehindHistory[client].Push(max(newestSequence - seq, 0));
+	}
+
+	DumpNetLagHistoriesIfNeeded();
+}
+
+static void DumpNetLagHistoriesIfNeeded()
+{
+	if (!net_lagdump || !netgame || demoplayback || LevelStartStatus != LST_READY)
+		return;
+
+	const int dumpSecond = gametic / TICRATE;
+	if (dumpSecond == LastLagDumpSecond)
+		return;
+	LastLagDumpSecond = dumpSecond;
+
+	const FString path = GetNetLagDumpPath();
+	FILE* file = fopen(path.GetChars(), "a");
+	if (file == nullptr)
+		return;
+
+	const int newestSeq = ClientTic / TicDup;
+	int lowestSeq = newestSeq;
+	for (auto client : NetworkClients)
+	{
+		if (client == consoleplayer || !IsTrackableClientForLagStats(client))
+			continue;
+		lowestSeq = min(lowestSeq, GetDisplayedClientSequenceForLagStats(client, newestSeq));
+	}
+
+	fprintf(file,
+		"g=%d seq=%d con=%d local_now=%d local_avg=%d local_max=%d local_ms=%d/%d/%d buffer=%d buffer_ms=%d\n",
+		gametic,
+		newestSeq,
+		CurrentConsistency,
+		LocalInputLagHistory.Current(),
+		LocalInputLagHistory.Average(),
+		LocalInputLagHistory.Max,
+		SeqTicsToMs(LocalInputLagHistory.Current()),
+		SeqTicsToMs(LocalInputLagHistory.Average()),
+		SeqTicsToMs(LocalInputLagHistory.Max),
+		max(StabilityBuffer, 0),
+		SeqTicsToMs(max(StabilityBuffer, 0)));
+
+	for (auto client : NetworkClients)
+	{
+		if (client == consoleplayer)
+			continue;
+
+		const bool tracked = IsTrackableClientForLagStats(client);
+		const int seq = tracked ? GetDisplayedClientSequenceForLagStats(client, newestSeq) : ClientStates[client].CurrentSequence;
+		fprintf(file,
+			"  p%d%s seq=%d ack=%d con=%d behind_now=%d behind_avg=%d behind_max=%d behind_ms=%d/%d/%d latency=%u flags=0x%x\n",
+			client + 1,
+			(tracked && seq == lowestSeq) ? " gate" : "",
+			seq,
+			ClientStates[client].SequenceAck,
+			ClientStates[client].CurrentNetConsistency,
+			tracked ? StreamBehindHistory[client].Current() : 0,
+			tracked ? StreamBehindHistory[client].Average() : 0,
+			tracked ? StreamBehindHistory[client].Max : 0,
+			tracked ? SeqTicsToMs(StreamBehindHistory[client].Current()) : 0,
+			tracked ? SeqTicsToMs(StreamBehindHistory[client].Average()) : 0,
+			tracked ? SeqTicsToMs(StreamBehindHistory[client].Max) : 0,
+			ClientStates[client].AverageLatency,
+			ClientStates[client].Flags);
+	}
+
+	fflush(file);
+	fclose(file);
+}
+
+static int16_t CalculatePendingJoinConsistency(int client, uint32_t seed)
+{
+	uint32_t value = seed ^ (0x45d9f3bu * static_cast<uint32_t>(client + 1));
+	value ^= (value >> 16);
+	int16_t consistency = static_cast<int16_t>(value & 0x7fff);
+	return consistency != 0 ? consistency : 1;
+}
+
+static bool ShouldSuppressMidgameJoinLocalCommands()
+{
+	return consoleplayer >= 0
+		&& consoleplayer != Net_Arbitrator
+		&& (IsWaitingForMidgameSpawn() || IsAwaitingMidgameActivation());
+}
+
+bool Net_ShouldSuppressMidgameJoinInput()
+{
+	return ShouldSuppressMidgameJoinLocalCommands();
+}
+
+static void SendMidgameStateActive()
+{
+	if (consoleplayer < 0 || consoleplayer == Net_Arbitrator)
+		return;
+
+	const auto& player = players[consoleplayer];
+	const uint8_t upPitch = static_cast<uint8_t>(clamp<int>(xs_RoundToInt(-player.MinPitch.Degrees()), 0, 127));
+	const uint8_t downPitch = static_cast<uint8_t>(clamp<int>(xs_RoundToInt(player.MaxPitch.Degrees()), 0, 127));
+	uint8_t buf[4] = { NCMD_SETUP, PRE_MIDGAME_STATE_ACTIVE, upPitch, downPitch };
+	I_SendSetupPacket(Net_Arbitrator, buf, 4);
+}
+
+static void ResendMidgameStateActiveIfNeeded()
+{
+	if (!IncomingStateTransfer.activeSent)
+		return;
+
+	SendMidgameStateActive();
+}
+
+static void ConfirmMidgameJoinActive(int joinerSlot)
+{
+	if (consoleplayer != Net_Arbitrator)
+		return;
+	if (joinerSlot < 0 || joinerSlot >= (int)MAXPLAYERS)
+		return;
+	if (!(ClientStates[joinerSlot].Flags & CF_JOINING)
+		|| !(ClientStates[joinerSlot].Flags & CF_AWAITING_ACTIVE))
+		return;
+
+	const int lastSeq = max(gametic / TicDup - 1, ClientStates[joinerSlot].CurrentSequence);
+	const int lastCon = max(CurrentConsistency - 1, ClientStates[joinerSlot].CurrentNetConsistency);
+	ClientStates[joinerSlot].CurrentSequence = lastSeq;
+	ClientStates[joinerSlot].SequenceAck = lastSeq;
+	ClientStates[joinerSlot].CurrentNetConsistency = lastCon;
+	ClientStates[joinerSlot].ConsistencyAck = lastCon;
+	ClientStates[joinerSlot].LastVerifiedConsistency = lastCon;
+	ClientStates[joinerSlot].Flags &= ~CF_AWAITING_ACTIVE;
+
+	const uint8_t upPitch = static_cast<uint8_t>(clamp<int>(xs_RoundToInt(-players[joinerSlot].MinPitch.Degrees()), 0, 127));
+	const uint8_t downPitch = static_cast<uint8_t>(clamp<int>(xs_RoundToInt(players[joinerSlot].MaxPitch.Degrees()), 0, 127));
+	Net_WriteInt8(DEM_MIDGAMEACTIVE);
+	Net_WriteInt8(static_cast<uint8_t>(joinerSlot));
+	Net_WriteInt8(upPitch);
+	Net_WriteInt8(downPitch);
+}
+
 static bool IsMapLoaded();
 void Net_SetupUserInfo();
 static uint32_t StaticSumSeeds();
@@ -1364,11 +1745,13 @@ void HandleMidgamePlayerJoin()
 	// Initialize client state for the new player.
 	auto& state = ClientStates[newPlayer];
 	memset(&state, 0, sizeof(FClientNetState));
-	state.CurrentSequence = gametic / TicDup;
-	state.SequenceAck = gametic / TicDup;
-	state.CurrentNetConsistency = CurrentConsistency;
-	state.ConsistencyAck = CurrentConsistency;
-	state.LastVerifiedConsistency = CurrentConsistency;
+	const int lastSeq = max(gametic / TicDup - 1, -1);
+	const int lastCon = max(CurrentConsistency - 1, -1);
+	state.CurrentSequence = lastSeq;
+	state.SequenceAck = lastSeq;
+	state.CurrentNetConsistency = lastCon;
+	state.ConsistencyAck = lastCon;
+	state.LastVerifiedConsistency = lastCon;
 	state.Flags = CF_JOINING;
 	state.LastPacketReceivedTime = I_msTime();
 
@@ -1508,7 +1891,7 @@ static void AbortStateTransfer()
 		if (NetworkClients.InGame(client))
 		{
 			SendSetupPacketToClient(client, PRE_MIDGAME_STATE_ERROR);
-			ClientStates[client].Flags &= ~(CF_JOINING | CF_AWAITING_STATE);
+			ClientStates[client].Flags &= ~(CF_JOINING | CF_AWAITING_STATE | CF_AWAITING_ACTIVE);
 			DisconnectClient(client);
 		}
 
@@ -1713,9 +2096,14 @@ void HandleMidgameStateComplete()
 	auto& xfer = IncomingStateTransfer;
 	if (!xfer.active)
 	{
-		// We already loaded the snapshot and sent STATE_LOADED, but the host
-		// didn't receive it (packet loss). Resend so the host can proceed.
-		if (xfer.loadedSent)
+		// We already loaded the snapshot or processed the spawn locally, but
+		// the host may have missed our last setup packet. Resend so it can
+		// continue the join handshake.
+		if (xfer.activeSent)
+		{
+			SendMidgameStateActive();
+		}
+		else if (xfer.loadedSent)
 		{
 			uint8_t buf[2] = { NCMD_SETUP, PRE_MIDGAME_STATE_LOADED };
 			I_SendSetupPacket(Net_Arbitrator, buf, 2);
@@ -1758,7 +2146,7 @@ void HandleMidgameStateReady()
 	{
 		Printf("Client %d became ready while the host was transitioning, aborting join\n", joinerSlot);
 		SendSetupPacketToClient(joinerSlot, PRE_MIDGAME_STATE_ERROR);
-		ClientStates[joinerSlot].Flags &= ~(CF_JOINING | CF_AWAITING_STATE);
+		ClientStates[joinerSlot].Flags &= ~(CF_JOINING | CF_AWAITING_STATE | CF_AWAITING_ACTIVE);
 		DisconnectClient(joinerSlot);
 		return;
 	}
@@ -1790,7 +2178,7 @@ void HandleMidgameStateLoaded()
 	if (!PendingStateTransfer.active || joinerSlot != PendingStateTransfer.clientNum)
 		return;
 
-	Printf("Client %d loaded game state, spawning player\n", joinerSlot);
+	Printf("Client %d loaded game state, waiting for activation sync\n", joinerSlot);
 
 	// Notify all existing clients that a new player is joining.
 	uint8_t buf[MAX_MSGLEN];
@@ -1819,8 +2207,8 @@ void HandleMidgameStateLoaded()
 
 	// Inject DEM_MIDGAMESPAWN into the host's event stream.
 	// All nodes (host + existing clients + joiner) will process this at the
-	// same gametic via the lockstep protocol, deterministically spawning the
-	// new player's actor.
+	// same gametic via the lockstep protocol, deterministically aligning the
+	// new player's network state before the real spawn happens at activation.
 	Net_WriteInt8(DEM_MIDGAMESPAWN);
 	Net_WriteInt8(static_cast<uint8_t>(joinerSlot));
 
@@ -1830,13 +2218,48 @@ void HandleMidgameStateLoaded()
 	// where the joiner needs commands that would never be sent. Without this,
 	// the joiner stalls for seconds while the retransmission mechanism slowly
 	// fills the gap one round-trip at a time.
-	ClientStates[joinerSlot].ResendSequenceFrom = PendingStateTransfer.hostGametic / TicDup;
+	const int lastSeq = max(PendingStateTransfer.hostGametic / TicDup - 1, -1);
+	const int lastCon = max(PendingStateTransfer.hostConsistency - 1, -1);
+	auto& joinState = ClientStates[joinerSlot];
+	joinState.CurrentSequence = lastSeq;
+	joinState.SequenceAck = lastSeq;
+	joinState.ResendSequenceFrom = PendingStateTransfer.hostGametic / TicDup;
+	joinState.CurrentNetConsistency = lastCon;
+	joinState.ConsistencyAck = lastCon;
+	joinState.LastVerifiedConsistency = lastCon;
+	joinState.ResendConsistencyFrom = -1;
+	joinState.Flags &= ~(CF_MISSING | CF_RETRANSMIT);
 
 	// Clear CF_AWAITING_STATE so duplicate STATE_LOADED packets won't
-	// re-trigger before DEM_MIDGAMESPAWN clears CF_JOINING.
-	ClientStates[joinerSlot].Flags &= ~CF_AWAITING_STATE;
+	// re-trigger while we wait for the joiner's first live gameplay command.
+	joinState.Flags &= ~CF_AWAITING_STATE;
+	joinState.Flags |= CF_AWAITING_ACTIVE;
 
 	PendingStateTransfer.Clear();
+}
+
+// Host receives: STATE_ACTIVE from joiner. This confirms the joiner has
+// processed the pre-activation sync point locally and is ready for the
+// deterministic activation/spawn event from the current host tic.
+void HandleMidgameStateActive()
+{
+	if (consoleplayer != Net_Arbitrator)
+		return;
+
+	const int joinerSlot = RemoteClient;
+	if (joinerSlot < 0
+		|| !(ClientStates[joinerSlot].Flags & CF_JOINING)
+		|| !(ClientStates[joinerSlot].Flags & CF_AWAITING_ACTIVE))
+		return;
+
+	if (NetBufferLength >= 4)
+	{
+		TArrayView<uint8_t> stream = TArrayView(&NetBuffer[2], NetBufferLength - 2);
+		players[joinerSlot].MinPitch = DAngle::fromDeg(-ReadInt8(stream));
+		players[joinerSlot].MaxPitch = DAngle::fromDeg(ReadInt8(stream));
+	}
+
+	ConfirmMidgameJoinActive(joinerSlot);
 }
 
 // Host/Joiner receives: error during state transfer.
@@ -1872,16 +2295,20 @@ void Net_PrepareMidgameSync()
 
 	// Clear local commands so we don't replay stale input.
 	memset(LocalCmds, 0, sizeof(LocalCmds));
+	const int lastSeq = max(ClientTic - 1, -1);
+	const int lastCon = max(CurrentConsistency - 1, -1);
 
 	// Initialize our own client state.
 	auto& state = ClientStates[consoleplayer];
+	const int preservedFlags = state.Flags & (CF_QUIT | CF_JOINING | CF_AWAITING_STATE | CF_AWAITING_ACTIVE);
 	memset(&state, 0, sizeof(FClientNetState));
-	state.CurrentSequence = ClientTic;
-	state.SequenceAck = ClientTic;
-	state.CurrentNetConsistency = CurrentConsistency;
-	state.ConsistencyAck = CurrentConsistency;
-	state.LastVerifiedConsistency = CurrentConsistency;
+	state.CurrentSequence = lastSeq;
+	state.SequenceAck = lastSeq;
+	state.CurrentNetConsistency = lastCon;
+	state.ConsistencyAck = lastCon;
+	state.LastVerifiedConsistency = lastCon;
 	state.LastPacketReceivedTime = I_msTime();
+	state.Flags = preservedFlags;
 
 	// Initialize sequence and consistency tracking for all existing clients.
 	// Without this, stale CurrentSequence values from the pre-game lobby
@@ -1891,11 +2318,11 @@ void Net_PrepareMidgameSync()
 	{
 		if (c != consoleplayer)
 		{
-			ClientStates[c].CurrentSequence = ClientTic;
-			ClientStates[c].SequenceAck = ClientTic;
-			ClientStates[c].LastVerifiedConsistency = CurrentConsistency;
-			ClientStates[c].CurrentNetConsistency = CurrentConsistency;
-			ClientStates[c].ConsistencyAck = CurrentConsistency;
+			ClientStates[c].CurrentSequence = lastSeq;
+			ClientStates[c].SequenceAck = lastSeq;
+			ClientStates[c].LastVerifiedConsistency = lastCon;
+			ClientStates[c].CurrentNetConsistency = lastCon;
+			ClientStates[c].ConsistencyAck = lastCon;
 		}
 	}
 
@@ -2233,6 +2660,15 @@ static void GetPackets()
 				{
 					pState.CurrentSequence = seq;
 				}
+				// A late joiner may miss the side-channel STATE_ACTIVE packet on
+				// heavy maps, but once the host receives the joiner's first
+				// post-spawn command stream we know the client is fully active.
+				if (consoleplayer == Net_Arbitrator
+					&& clientNum == pNum
+					&& (clientState.Flags & CF_AWAITING_ACTIVE))
+				{
+					ConfirmMidgameJoinActive(clientNum);
+				}
 				// Update this so host switching doesn't have any hiccups.
 				if (consoleplayer != Net_Arbitrator && pNum != Net_Arbitrator)
 					pState.SequenceAck = seq;
@@ -2293,7 +2729,7 @@ static void CheckConsistencies()
 	// if the client's current position doesn't agree with the host.
 	for (auto client : NetworkClients)
 	{
-		if (!playeringame[client])
+		if (!playeringame[client] || IsDedicatedControlStream(client))
 			continue;
 
 		auto& clientState = ClientStates[client];
@@ -2349,6 +2785,9 @@ static uint32_t StaticSumSeeds()
 
 static int16_t CalculateConsistency(int client, uint32_t seed)
 {
+	if (IsDedicatedControlStream(client))
+		return 1;
+
 	if (players[client].mo != nullptr)
 	{
 		seed += int((players[client].mo->X() + players[client].mo->Y() + players[client].mo->Z()) * 257) + players[client].mo->Angles.Yaw.BAMs() + players[client].mo->Angles.Pitch.BAMs();
@@ -2358,7 +2797,6 @@ static int16_t CalculateConsistency(int client, uint32_t seed)
 	// Zero value consistencies are seen as invalid, so always have a valid value.
 	return (seed & 0xFFFF) ? seed : 1;
 }
-
 
 // Ran a tick, so prep the next consistencies to send out.
 // [RH] Include some random seeds and player stuff in the consistancy
@@ -2372,13 +2810,16 @@ static void MakeConsistencies()
 
 	for (auto client : NetworkClients)
 	{
-		if (!playeringame[client])
-			continue;
-		// Skip the ghost player on dedicated servers — it has no real input
-		// and its state is irrelevant to gameplay consistency.
-		if ((dedicatedServer || hostIsDedicated) && client == 0)
-			continue;
 		auto& clientState = ClientStates[client];
+		if (!playeringame[client])
+		{
+			if (clientState.Flags & (CF_JOINING | CF_AWAITING_STATE | CF_AWAITING_ACTIVE))
+			{
+				clientState.LocalConsistency[CurrentConsistency % BACKUPTICS] =
+					CalculatePendingJoinConsistency(client, rngSum);
+			}
+			continue;
+		}
 		clientState.LocalConsistency[CurrentConsistency % BACKUPTICS] = CalculateConsistency(client, rngSum);
 	}
 
@@ -2565,7 +3006,7 @@ void NetUpdate(int tics)
 						&& (now - state.LastPacketReceivedTime) >= STATE_TRANSFER_TOTAL_TIMEOUT_MS)
 					{
 						Printf("Joining client %d timed out (state transfer never started)\n", client);
-						ClientStates[client].Flags &= ~(CF_JOINING | CF_AWAITING_STATE);
+						ClientStates[client].Flags &= ~(CF_JOINING | CF_AWAITING_STATE | CF_AWAITING_ACTIVE);
 						DisconnectClient(client);
 					}
 					continue;
@@ -2655,15 +3096,24 @@ void NetUpdate(int tics)
 			continue;
 		}
 
-		if (dedicatedServer)
-		{
-			// Dedicated server generates empty commands — no input, no actor.
-			memset(&LocalCmds[ClientTic++ % LOCALCMDTICS], 0, sizeof(usercmd_t));
-		}
-		else
-		{
-			G_BuildTiccmd(&LocalCmds[ClientTic++ % LOCALCMDTICS]);
-		}
+			if (dedicatedServer)
+			{
+				// Dedicated server generates empty commands — no input, no actor.
+				memset(&LocalCmds[ClientTic++ % LOCALCMDTICS], 0, sizeof(usercmd_t));
+			}
+			else if (ShouldSuppressMidgameJoinLocalCommands())
+			{
+				// Keep consuming remote tics so DEM_MIDGAMESPAWN and
+				// DEM_MIDGAMEACTIVE can execute, but do not generate or send local
+				// gameplay commands before the joiner is officially activated.
+				continue;
+			}
+			else
+			{
+				const int localTic = ClientTic++;
+				auto& built = LocalCmds[localTic % LOCALCMDTICS];
+				G_BuildTiccmd(&built);
+			}
 		if (TicDup == 1)
 		{
 			Net_NewClientTic();
@@ -2738,6 +3188,15 @@ void NetUpdate(int tics)
 		for (auto client : NetworkClients)
 			ClientStates[client].CurrentSequence = newestTic;
 
+		return;
+	}
+
+	// While waiting for DEM_MIDGAMESPAWN, the late joiner should only
+	// receive host data. Sending normal gameplay packets here just echoes the
+	// host stream back and confuses retransmit bookkeeping.
+	if (ShouldSuppressMidgameJoinLocalCommands())
+	{
+		GetPackets();
 		return;
 	}
 
@@ -2926,7 +3385,6 @@ void NetUpdate(int tics)
 					if (curState.ResendSequenceFrom >= endSequence)
 						curState.ResendSequenceFrom = -1;
 				}
-
 				NetBuffer[size++] = sendTics;
 				if (sendTics > 0)
 				{
@@ -3228,7 +3686,7 @@ bool D_CheckNetGame()
 	const uint64_t startTime = I_msTime();
 	for (auto client : NetworkClients)
 	{
-		// Mid-game joiner: skip our own slot — we enter via DEM_MIDGAMESPAWN later.
+		// Mid-game joiner: skip our own slot — we enter via DEM_MIDGAMEACTIVE later.
 		if (gameaction == ga_midgamejoin && client == consoleplayer)
 			continue;
 
@@ -3471,6 +3929,13 @@ ADD_STAT(network)
 		consoleplayer == Net_Arbitrator,
 		delay, msDelay,
 		buffer, msBuffer);
+	out.AppendFormat("\tInput lag now/avg/max: %02d/%02d/%02d (%03d/%03d/%03dms)",
+		LocalInputLagHistory.Current(),
+		LocalInputLagHistory.Average(),
+		LocalInputLagHistory.Max,
+		SeqTicsToMs(LocalInputLagHistory.Current()),
+		SeqTicsToMs(LocalInputLagHistory.Average()),
+		SeqTicsToMs(LocalInputLagHistory.Max));
 
 	if (consoleplayer != Net_Arbitrator)
 		out.AppendFormat("\tAvg latency: %03ums", min<unsigned int>(ClientStates[consoleplayer].AverageLatency, 999u));
@@ -3485,19 +3950,35 @@ ADD_STAT(network)
 			out.AppendFormat("\tWaiting for arbitrator");
 	}
 
-	int lowestSeq = ClientTic / TicDup;
+	const int newestSeq = ClientTic / TicDup;
+	int lowestSeq = newestSeq;
 	for (auto client : NetworkClients)
 	{
 		if (client == consoleplayer)
 			continue;
 
 		auto& state = ClientStates[client];
-		if (state.CurrentSequence < lowestSeq)
-			lowestSeq = state.CurrentSequence;
+		if (!IsTrackableClientForLagStats(client))
+			continue;
+		const int seq = GetDisplayedClientSequenceForLagStats(client, newestSeq);
+		if (seq < lowestSeq)
+			lowestSeq = seq;
+	}
+
+	for (auto client : NetworkClients)
+	{
+		if (client == consoleplayer)
+			continue;
+
+		auto& state = ClientStates[client];
+		const bool tracked = IsTrackableClientForLagStats(client);
+		const int seq = tracked ? GetDisplayedClientSequenceForLagStats(client, newestSeq) : state.CurrentSequence;
 
 		out.AppendFormat("\n%s", players[client].userinfo.GetName(12));
 		if (client == Net_Arbitrator)
-			out.AppendFormat("\t(Host)");
+			out.AppendFormat(IsDedicatedControlStream(client) ? "\t(Host Ctrl)" : "\t(Host)");
+		if (tracked && seq == lowestSeq)
+			out.AppendFormat("\t(Gate)");
 
 		if ((state.Flags & CF_RETRANSMIT) == CF_RETRANSMIT)
 			out.AppendFormat("\t(RT)");
@@ -3515,7 +3996,18 @@ ADD_STAT(network)
 
 		out.AppendFormat("\n");
 		
-		out.AppendFormat("\tAck: %06d\tConsistency: %06d", state.SequenceAck, state.ConsistencyAck);
+		out.AppendFormat("\tSeq: %06d\tAck: %06d\tConsistency: %06d",
+			seq, state.SequenceAck, state.ConsistencyAck);
+		if (tracked)
+		{
+			out.AppendFormat("\tBehind now/avg/max: %02d/%02d/%02d (%03d/%03d/%03dms)",
+				StreamBehindHistory[client].Current(),
+				StreamBehindHistory[client].Average(),
+				StreamBehindHistory[client].Max,
+				SeqTicsToMs(StreamBehindHistory[client].Current()),
+				SeqTicsToMs(StreamBehindHistory[client].Average()),
+				SeqTicsToMs(StreamBehindHistory[client].Max));
+		}
 		if (client != Net_Arbitrator)
 			out.AppendFormat("\tAvg latency: %03ums", min<unsigned int>(state.AverageLatency, 999u));
 	}
@@ -3623,6 +4115,11 @@ void TryRunTics()
 {
 	GC::CheckGC();
 
+	auto shouldHibernateNow = [&]()
+	{
+		return ShouldHibernateDedicatedServer();
+	};
+
 	if (ToggleFullscreen)
 	{
 		ToggleFullscreen = false;
@@ -3648,27 +4145,48 @@ void TryRunTics()
 	if (totalTics > 1 && singletics)
 		totalTics = 1;
 
+	// If the joiner already spawned locally but the host has not yet confirmed
+	// activation, keep nudging the host with STATE_ACTIVE. The confirmation
+	// comes back as DEM_MIDGAMEACTIVE through the normal lockstep stream.
+	ResendMidgameStateActiveIfNeeded();
+
+	// A dedicated server with no real players should stay packet-responsive
+	// but must not advance local command generation while hibernating.
+	if (shouldHibernateNow())
+	{
+		NetUpdate(0);
+		LastEnterTic = EnterTic;
+
+		if (pauseext)
+			return;
+
+		if (shouldHibernateNow())
+		{
+			LastGameUpdate = EnterTic;
+			LagState = LAG_NONE;
+			for (auto client : NetworkClients)
+				players[client].waiting = false;
+			return;
+		}
+	}
+
+	// While the snapshot is still being transferred/loaded, the joiner cannot
+	// participate in the lockstep yet.
+	if (gameaction == ga_midgamejoin)
+	{
+		NetUpdate(0);
+
+		G_DoMidgameJoin();
+
+		LastEnterTic = EnterTic;
+		return;
+	}
+
 	// Listen for other clients and send out data as needed. This is also
 	// needed for singleplayer! But is instead handled entirely through local
 	// buffers. This has a limit of one seconds worth of commands that can be
 	// generated in advanced from the last time the game updated.
 	NetUpdate(totalTics);
-
-	// Mid-game join: process state transfer outside the lockstep. The joining
-	// client is blocked at tics=0 because it has no commands from the host yet.
-	// G_DoMidgameJoin only does I/O (request state, receive chunks, load snapshot)
-	// — the actual player spawn goes through DEM_MIDGAMESPAWN via the lockstep.
-	if (gameaction == ga_midgamejoin)
-	{
-		G_DoMidgameJoin();
-		// Keep LastEnterTic current so that when ga_midgamejoin clears,
-		// the next TryRunTics doesn't see a huge totalTics burst.
-		// Without this, NetUpdate generates hundreds of commands at once
-		// but MAXSENDTICS only sends 35 — the rest are never sent,
-		// creating a gap that freezes the host after exactly 35 tics.
-		LastEnterTic = EnterTic;
-		return;
-	}
 
 	LastEnterTic = EnterTic;
 
@@ -3676,11 +4194,27 @@ void TryRunTics()
 	if (pauseext)
 		return;
 
+	if (shouldHibernateNow())
+	{
+		LastGameUpdate = EnterTic;
+		LagState = LAG_NONE;
+		for (auto client : NetworkClients)
+			players[client].waiting = false;
+		return;
+	}
+
 	// Get the amount of tics the client can actually run. This accounts for waiting for other
 	// players over the network.
 	int lowestSequence = INT_MAX;
 	for (auto client : NetworkClients)
 	{
+		// A waiting late-joiner has no local gameplay command stream yet.
+		// If we include its own slot here, lowestSequence gets pinned to the
+		// snapshot baseline and the client never advances far enough to
+		// execute DEM_MIDGAMESPAWN from the host event stream.
+		if (ShouldSuppressMidgameJoinLocalCommands() && client == consoleplayer)
+			continue;
+
 		// Skip joining clients — they have no commands yet and would block the lockstep.
 		// Skip quitting clients — they stopped sending commands and will be removed by
 		// NCMD_QUITTERS (network) + DEM_PLAYERDISCONNECT (game state) shortly.
@@ -3726,6 +4260,8 @@ void TryRunTics()
 		if (totalTics < availableTics - StabilityBuffer)
 			++runTics;
 	}
+
+	SampleNetLagHistories();
 
 	const int worldTimer = primaryLevel->LocalWorldTimer;
 	// If there are no tics to run, check for possible stall conditions and new
@@ -4651,10 +5187,6 @@ void Net_DoCommand(int cmd, TArrayView<uint8_t>& stream, int player)
 		const int pnum = ReadInt8(stream);
 		if (pnum >= 0 && pnum < (int)MAXPLAYERS && !playeringame[pnum])
 		{
-			playeringame[pnum] = true;
-			players[pnum].playerstate = PST_ENTER;
-			// Clear the joining flags now that they're officially in the game.
-			ClientStates[pnum].Flags &= ~(CF_JOINING | CF_AWAITING_STATE);
 			// Synchronize the joiner's command sequence to the current gametic
 			// on ALL nodes. ClientConnecting set CurrentSequence at CONNECT time
 			// (before V_Init2/state transfer), so it's now stale by hundreds of
@@ -4662,40 +5194,81 @@ void Net_DoCommand(int cmd, TArrayView<uint8_t>& stream, int player)
 			// in TryRunTics, freezing the entire lockstep until the joiner's
 			// actual commands catch up — causing a multi-second freeze for all
 			// clients and subsequent input lag from command pileup.
-			ClientStates[pnum].CurrentSequence = gametic / TicDup;
-			ClientStates[pnum].SequenceAck = gametic / TicDup;
+			const int lastSeq = max(gametic / TicDup - 1, -1);
+			const int lastCon = max(CurrentConsistency - 1, -1);
+			ClientStates[pnum].CurrentSequence = lastSeq;
+			ClientStates[pnum].SequenceAck = lastSeq;
 			// Initialize consistency tracking for the new player on all nodes,
-			// and for all existing players on the joiner's node. Without this,
-			// stale circular buffer entries would cause false desyncs.
-			ClientStates[pnum].LastVerifiedConsistency = CurrentConsistency;
-			ClientStates[pnum].CurrentNetConsistency = CurrentConsistency;
-			ClientStates[pnum].ConsistencyAck = CurrentConsistency;
+			// using the last completed world tic. The packet carrying
+			// DEM_MIDGAMESPAWN may already have advanced the existing streams to
+			// the first post-snapshot tic, so do not overwrite those here.
+			ClientStates[pnum].LastVerifiedConsistency = lastCon;
+			ClientStates[pnum].CurrentNetConsistency = lastCon;
+			ClientStates[pnum].ConsistencyAck = lastCon;
+
+			// On the joiner's node, this is now just the catch-up barrier:
+			// the snapshot world is already renderable, but the real pawn is not
+			// spawned until DEM_MIDGAMEACTIVE. That avoids exposing a helpless
+			// player to gameplay during the activation handshake.
 			if (pnum == consoleplayer)
 			{
-				// This is the joiner processing its own spawn. Initialize
-				// consistency tracking for all existing clients too.
-				for (auto c : NetworkClients)
-				{
-					if (c != pnum)
-					{
-						ClientStates[c].LastVerifiedConsistency = CurrentConsistency;
-						ClientStates[c].CurrentNetConsistency = CurrentConsistency;
-						ClientStates[c].ConsistencyAck = CurrentConsistency;
-					}
-				}
-			}
-			// Immediately spawn the player via DoReborn to avoid P_PlayerThink
-			// seeing a null mo before the next G_Ticker spawn loop runs.
-			primaryLevel->DoReborn(pnum, true);
-			// On the joiner's node, clear stale prediction data so the first
-			// P_PredictClient call starts fresh with the newly spawned actor.
-			if (pnum == consoleplayer)
-			{
-				P_ClearPredictionData();
+				G_ApplyRendererPitchLimitsToPlayer(pnum);
 				IncomingStateTransfer.loadedSent = false;
+				IncomingStateTransfer.activeSent = true;
+				SendMidgameStateActive();
 			}
-			// RNG state is synchronized via full serialization in the state
-			// transfer (globals portion). No seed-based reset needed.
+		}
+		break;
+	}
+
+	case DEM_MIDGAMEACTIVE:
+	{
+		const int pnum = ReadInt8(stream);
+		if (pnum >= 0 && pnum < (int)MAXPLAYERS)
+		{
+			auto& netState = ClientStates[pnum];
+			const DAngle minPitch = DAngle::fromDeg(-ReadInt8(stream));
+			const DAngle maxPitch = DAngle::fromDeg(ReadInt8(stream));
+			const int lastSeq = max(gametic / TicDup - 1, 0);
+			const int lastCon = max(CurrentConsistency - 1, 0);
+			if (!playeringame[pnum])
+			{
+				playeringame[pnum] = true;
+				players[pnum].playerstate = PST_ENTER;
+				primaryLevel->DoReborn(pnum, true);
+			}
+			players[pnum].MinPitch = minPitch;
+			players[pnum].MaxPitch = maxPitch;
+			// Activation is the first moment this player is truly live.
+			// Existing clients must advance the slot's stream baseline here too,
+			// otherwise lowestSequence gets pinned by the stale pre-activation
+			// sequence and everyone stalls waiting on a stream that should now
+			// start from the live activation point.
+			netState.CurrentSequence = max(netState.CurrentSequence, lastSeq);
+			netState.SequenceAck = max(netState.SequenceAck, netState.CurrentSequence);
+			netState.CurrentNetConsistency = max(netState.CurrentNetConsistency, lastCon);
+			netState.ConsistencyAck = max(netState.ConsistencyAck, netState.CurrentNetConsistency);
+			netState.LastVerifiedConsistency = max(netState.LastVerifiedConsistency, netState.CurrentNetConsistency);
+			netState.ResendSequenceFrom = -1;
+			netState.ResendConsistencyFrom = -1;
+			netState.Flags &= ~(CF_JOINING | CF_AWAITING_STATE | CF_AWAITING_ACTIVE | CF_MISSING | CF_RETRANSMIT);
+			if (pnum == consoleplayer)
+			{
+				const int nextClientTic = ((gametic / TicDup) + 1) * TicDup;
+				if (ClientTic < nextClientTic)
+					ClientTic = nextClientTic;
+				memset(LocalCmds, 0, sizeof(LocalCmds));
+				NetEvents.ResetStream();
+				SkipCommandTimer = SkipCommandAmount = CommandsAhead = 0;
+				netState.CurrentSequence = max(ClientTic / TicDup - 1, 0);
+				netState.SequenceAck = netState.CurrentSequence;
+				netState.CurrentNetConsistency = lastCon;
+				netState.ConsistencyAck = netState.CurrentNetConsistency;
+				netState.LastVerifiedConsistency = netState.CurrentNetConsistency;
+				G_ClearMidgameJoinRenderState();
+				P_ClearPredictionData();
+				IncomingStateTransfer.activeSent = false;
+			}
 			Printf("Player %d has joined the game\n", pnum + 1);
 		}
 		break;
@@ -4820,6 +5393,7 @@ void Net_SkipCommand(int cmd, TArrayView<uint8_t>& stream)
 		case DEM_KICK:
 		case DEM_WEAPSELECT:
 		case DEM_MIDGAMESPAWN:
+		case DEM_MIDGAMEACTIVE:
 		case DEM_PLAYERDISCONNECT:
 			skip = 1;
 			break;
@@ -4986,6 +5560,19 @@ CCMD(pings)
 		if (client != Net_Arbitrator)
 			Printf("%ums %s [%d]\n", ClientStates[client].AverageLatency, players[client].userinfo.GetName(), client);
 	}
+}
+
+CCMD(netlagreset)
+{
+	ResetNetLagHistories();
+	Printf("Network lag metrics reset.\n");
+	if (net_lagdump)
+		Printf("Dump file reset: %s\n", GetNetLagDumpPath().GetChars());
+}
+
+CCMD(netlagdumpfile)
+{
+	Printf("%s\n", GetNetLagDumpPath().GetChars());
 }
 
 CCMD(kick)

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -1336,6 +1336,17 @@ void HandleMidgamePlayerJoin()
 		return;
 
 	const int newPlayer = NetBuffer[2];
+	if (newPlayer < 0 || newPlayer >= (int)MAXPLAYERS)
+		return;
+
+	// Duplicate join notifications can carry the joiner's finalized userinfo
+	// once the host has it, so always apply any appended payload first.
+	if (NetBufferLength > 3)
+	{
+		TArrayView<uint8_t> stream = TArrayView(&NetBuffer[3], NetBufferLength - 3);
+		D_ReadUserInfoStrings(newPlayer, stream, false);
+	}
+
 	if (NetworkClients.InGame(newPlayer))
 	{
 		// Already know about this player (retransmitted PLAYER_JOIN). Just ACK again.
@@ -1734,6 +1745,12 @@ void HandleMidgameStateReady()
 	if (PendingStateTransfer.active)
 		return; // Already transferring state to someone.
 
+	if (NetBufferLength > 2)
+	{
+		TArrayView<uint8_t> stream = TArrayView(&NetBuffer[2], NetBufferLength - 2);
+		D_ReadUserInfoStrings(joinerSlot, stream, false);
+	}
+
 	Printf("Client %d ready for state, taking snapshot...\n", joinerSlot);
 	BeginStateTransfer(joinerSlot);
 }
@@ -1758,14 +1775,28 @@ void HandleMidgameStateLoaded()
 	Printf("Client %d loaded game state, spawning player\n", joinerSlot);
 
 	// Notify all existing clients that a new player is joining.
-	uint8_t buf[3];
-	buf[0] = NCMD_SETUP;
-	buf[1] = PRE_MIDGAME_PLAYER_JOIN;
-	buf[2] = static_cast<uint8_t>(joinerSlot);
+	uint8_t buf[MAX_MSGLEN];
+	size_t pos = 0;
+	buf[pos++] = NCMD_SETUP;
+	buf[pos++] = PRE_MIDGAME_PLAYER_JOIN;
+	buf[pos++] = static_cast<uint8_t>(joinerSlot);
+
+	const FString userinfo = D_GetUserInfoStrings(joinerSlot, true);
+	const size_t userinfoSize = userinfo.Len() + 1;
+	if (pos + userinfoSize > MAX_MSGLEN)
+	{
+		Printf("HandleMidgameStateLoaded: userinfo too large for player %d (%zu bytes)\n", joinerSlot, userinfoSize);
+	}
+	else
+	{
+		memcpy(&buf[pos], userinfo.GetChars(), userinfoSize);
+		pos += userinfoSize;
+	}
+
 	for (auto c : NetworkClients)
 	{
 		if (c != consoleplayer && c != joinerSlot)
-			I_SendSetupPacket(c, buf, 3);
+			I_SendSetupPacket(c, buf, pos);
 	}
 
 	// Inject DEM_MIDGAMESPAWN into the host's event stream.

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -5224,11 +5224,11 @@ void Net_DoCommand(int cmd, TArrayView<uint8_t>& stream, int player)
 	case DEM_MIDGAMEACTIVE:
 	{
 		const int pnum = ReadInt8(stream);
+		const DAngle minPitch = DAngle::fromDeg(-ReadInt8(stream));
+		const DAngle maxPitch = DAngle::fromDeg(ReadInt8(stream));
 		if (pnum >= 0 && pnum < (int)MAXPLAYERS)
 		{
 			auto& netState = ClientStates[pnum];
-			const DAngle minPitch = DAngle::fromDeg(-ReadInt8(stream));
-			const DAngle maxPitch = DAngle::fromDeg(ReadInt8(stream));
 			const int lastSeq = max(gametic / TicDup - 1, 0);
 			const int lastCon = max(CurrentConsistency - 1, 0);
 			if (!playeringame[pnum])
@@ -5393,9 +5393,12 @@ void Net_SkipCommand(int cmd, TArrayView<uint8_t>& stream)
 		case DEM_KICK:
 		case DEM_WEAPSELECT:
 		case DEM_MIDGAMESPAWN:
-		case DEM_MIDGAMEACTIVE:
 		case DEM_PLAYERDISCONNECT:
 			skip = 1;
+			break;
+
+		case DEM_MIDGAMEACTIVE:
+			skip = 3;
 			break;
 
 		case DEM_SAVEGAME:

--- a/src/d_net.h
+++ b/src/d_net.h
@@ -49,6 +49,7 @@ enum EClientFlags
 	CF_DISCONNECT_NOTIFIED = 1 << 7,	// Host has notified others about this client's departure.
 	CF_JOINING = 1 << 8,				// Client is in the process of joining mid-game.
 	CF_AWAITING_STATE = 1 << 9,			// Client is waiting for game state transfer.
+	CF_AWAITING_ACTIVE = 1 << 10,		// Host is waiting for the joiner to confirm the pre-activation sync point.
 
 	CF_RETRANSMIT = CF_RETRANSMIT_CON | CF_RETRANSMIT_SEQ,
 	CF_MISSING = CF_MISSING_CON | CF_MISSING_SEQ,
@@ -163,6 +164,7 @@ double Net_ModifyParticleFrac(particle_t* part, double ticFrac);
 
 // True on clients connected to a dedicated server (host player 0 is a ghost).
 extern bool					hostIsDedicated;
+bool						Net_IsGhostPlayer(int player);
 
 // Netgame stuff (buffers and pointers, i.e. indices).
 
@@ -222,10 +224,13 @@ void HandleMidgameStateBegin();
 void HandleMidgameStateChunk();
 void HandleMidgameStateChunkAck();
 void HandleMidgameStateComplete();
+void HandleMidgameStateReady();
 void HandleMidgameStateLoaded();
+void HandleMidgameStateActive();
 void HandleMidgameStateError();
 
 void Net_PrepareMidgameSync();
+bool Net_ShouldSuppressMidgameJoinInput();
 extern struct FStateTransferRecv IncomingStateTransfer;
 
 // Chunk size for mid-game state transfer (fits in MaxTransmitSize after headers + compression).
@@ -259,6 +264,7 @@ struct FStateTransferRecv
 {
 	bool		active = false;
 	bool		loadedSent = false;	// True after STATE_LOADED was sent to host
+	bool		activeSent = false;	// True after STATE_ACTIVE was sent to host
 	TArray<uint8_t>	data;			// Reassembly buffer
 	size_t		totalSize = 0;
 	size_t		globalsSize = 0;

--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -809,6 +809,7 @@ void D_ReadUserInfoStrings (int pnum, TArrayView<uint8_t>& stream, bool update)
 	bool compact;
 	FName keyname = NAME_None;
 	unsigned int infotype = 0;
+	int skinPlayerClass = players[pnum].CurrentPlayerClass;
 
 	if (*ptr++ != '\\')
 		return;
@@ -865,64 +866,68 @@ void D_ReadUserInfoStrings (int pnum, TArrayView<uint8_t>& stream, bool update)
 				keyname = FName(ptr, valstart - ptr - 1, true);
 			}
 			
-			// A few of these need special handling.
-			switch (keyname.GetIndex())
-			{
-			case NAME_Gender:
-				info->GenderChanged(value.GetChars());
-				break;
-
-			case NAME_PlayerClass:
-				info->PlayerClassChanged(value.GetChars());
-				break;
-
-			case NAME_Skin:
-				info->SkinChanged(value.GetChars(), players[pnum].CurrentPlayerClass);
-				if (players[pnum].mo != NULL)
+				// A few of these need special handling.
+				switch (keyname.GetIndex())
 				{
-					if (players[pnum].cls != NULL &&
-						!(players[pnum].mo->flags4 & MF4_NOSKIN) &&
-						players[pnum].mo->state->sprite ==
-						GetDefaultByType (players[pnum].cls)->SpawnState->sprite)
-					{ // Only change the sprite if the player is using a standard one
-						players[pnum].mo->sprite = Skins[info->GetSkin()].sprite;
-					}
-				}
-				// Rebuild translation in case the new skin uses a different range
-				// than the old one.
-				R_BuildPlayerTranslation(pnum);
-				break;
+				case NAME_Gender:
+					info->GenderChanged(value.GetChars());
+					break;
 
-			case NAME_Team:
-				UpdateTeam(pnum, atoi(value.GetChars()), update);
-				break;
-
-			case NAME_Color:
-				info->ColorChanged(value.GetChars());
-				break;
-
-			default:
-				cvar_ptr = info->CheckKey(keyname);
-				if (cvar_ptr != NULL)
+				case NAME_PlayerClass:
 				{
-					assert(*cvar_ptr != NULL);
-					UCVarValue val;
-					FString oldname;
-
-					if (keyname == NAME_Name)
-					{
-						val = (*cvar_ptr)->GetGenericRep(CVAR_String);
-						oldname = val.String;
-					}
-					val.String = CleanseString(value.LockBuffer());
-					(*cvar_ptr)->SetGenericRep(val, CVAR_String);
-					value.UnlockBuffer();
-					if (keyname == NAME_Name && update && oldname.Compare (value))
-					{
-						Printf("%s is now known as %s\n", oldname.GetChars(), value.GetChars());
-					}
+					const int classnum = info->PlayerClassChanged(value.GetChars());
+					if (classnum >= 0 && classnum < (int)PlayerClasses.Size())
+						skinPlayerClass = classnum;
+					break;
 				}
-				break;
+
+				case NAME_Skin:
+					info->SkinChanged(value.GetChars(), skinPlayerClass);
+					if (players[pnum].mo != NULL)
+					{
+						if (players[pnum].cls != NULL &&
+							!(players[pnum].mo->flags4 & MF4_NOSKIN) &&
+							players[pnum].mo->state->sprite ==
+							GetDefaultByType (players[pnum].cls)->SpawnState->sprite)
+						{ // Only change the sprite if the player is using a standard one
+							players[pnum].mo->sprite = Skins[info->GetSkin()].sprite;
+						}
+					}
+					// Rebuild translation in case the new skin uses a different range
+					// than the old one.
+					R_BuildPlayerTranslation(pnum);
+					break;
+
+				case NAME_Team:
+					UpdateTeam(pnum, atoi(value.GetChars()), update);
+					break;
+
+				case NAME_Color:
+					info->ColorChanged(value.GetChars());
+					break;
+
+				default:
+					cvar_ptr = info->CheckKey(keyname);
+					if (cvar_ptr != NULL)
+					{
+						assert(*cvar_ptr != NULL);
+						UCVarValue val;
+						FString oldname;
+
+						if (keyname == NAME_Name)
+						{
+							val = (*cvar_ptr)->GetGenericRep(CVAR_String);
+							oldname = val.String;
+						}
+						val.String = CleanseString(value.LockBuffer());
+						(*cvar_ptr)->SetGenericRep(val, CVAR_String);
+						value.UnlockBuffer();
+						if (keyname == NAME_Name && update && oldname.Compare (value))
+						{
+							Printf("%s is now known as %s\n", oldname.GetChars(), value.GetChars());
+						}
+					}
+					break;
 			}
 			if (keyname == NAME_Color || keyname == NAME_ColorSet)
 			{

--- a/src/d_protocol.h
+++ b/src/d_protocol.h
@@ -162,8 +162,9 @@ enum EDemoCommand
 	DEM_READIED,		// 77
 	DEM_WEAPSELECT,		// 78 Byte: Slot
 	DEM_USEFLECHETTE,	// 79
-	DEM_MIDGAMESPAWN,	// 80 Byte: Player number to spawn mid-game
+	DEM_MIDGAMESPAWN,	// 80 Byte: Player number pre-activation sync point
 	DEM_PLAYERDISCONNECT,	// 81 Byte: Player number to remove deterministically
+	DEM_MIDGAMEACTIVE,	// 82 Byte: Player number is fully active and spawned
 };
 
 // The following are implemented by cht_DoCheat in m_cheat.cpp

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2057,6 +2057,28 @@ void G_SerializeMidgameGlobalsPostInit(FSerializer& arc)
 	}
 }
 
+void G_ApplyRendererPitchLimitsToPlayer(int player)
+{
+	if (player < 0 || player >= (int)MAXPLAYERS)
+		return;
+
+	int uppitch, downpitch;
+	if (!V_IsHardwareRenderer())
+	{
+		int maxvp = min(56, (int)maxviewpitch);
+		int maxup = min(32, (int)maxviewpitch);
+		uppitch = cl_oldfreelooklimit ? maxup : maxvp;
+		downpitch = maxvp;
+	}
+	else
+	{
+		uppitch = downpitch = (int)maxviewpitch;
+	}
+
+	players[player].MinPitch = DAngle::fromDeg(-(double)uppitch);
+	players[player].MaxPitch = DAngle::fromDeg((double)downpitch);
+}
+
 
 void SetupLoadingCVars();
 void FinishLoadingCVars();
@@ -2073,12 +2095,66 @@ bool CheckGZDoomSaveCompat(FString &engine, FString &software);
 
 static bool bMidgameStateRequested = false;
 static uint64_t midgameJoinStartTime = 0;
+static bool bMidgameJoinRenderReady = false;
+static constexpr int MaxPlayersInt = (int)MAXPLAYERS;
+
+static AActor* PickMidgameJoinRenderCamera()
+{
+	if (consoleplayer >= 0 && consoleplayer < MaxPlayersInt && players[consoleplayer].mo != nullptr)
+		return players[consoleplayer].mo;
+
+	AActor* ghostFallback = nullptr;
+
+	for (int i = 0; i < MaxPlayersInt; ++i)
+	{
+		if (!playeringame[i])
+			continue;
+
+		if (Net_IsGhostPlayer(i))
+		{
+			if (ghostFallback == nullptr)
+				ghostFallback = players[i].mo != nullptr ? players[i].mo : players[i].camera;
+			continue;
+		}
+
+		if (players[i].mo != nullptr)
+			return players[i].mo;
+		if (players[i].camera != nullptr)
+			return players[i].camera;
+	}
+
+	return ghostFallback;
+}
+
+bool G_CanRenderMidgameJoinView()
+{
+	return gamestate == GS_LEVEL
+		&& consoleplayer >= 0
+		&& consoleplayer < MaxPlayersInt
+		&& !playeringame[consoleplayer]
+		&& bMidgameJoinRenderReady
+		&& players[consoleplayer].camera != nullptr;
+}
+
+void G_ClearMidgameJoinRenderState()
+{
+	bMidgameJoinRenderReady = false;
+
+	if (consoleplayer < 0 || consoleplayer >= MaxPlayersInt)
+		return;
+
+	if (playeringame[consoleplayer] && players[consoleplayer].mo != nullptr)
+		players[consoleplayer].camera = players[consoleplayer].mo;
+	else
+		players[consoleplayer].camera = nullptr;
+}
 
 void G_AbortMidgameJoin()
 {
 	gameaction = ga_fullconsole;
 	bMidgameStateRequested = false;
 	midgameJoinStartTime = 0;
+	G_ClearMidgameJoinRenderState();
 	IncomingStateTransfer.Clear();
 }
 
@@ -2201,6 +2277,7 @@ void G_DoMidgameJoin()
 	// The joiner is NOT in the game yet — their slot will be activated via
 	// DEM_MIDGAMESPAWN after we signal STATE_LOADED.
 	playeringame[consoleplayer] = false;
+	G_ClearMidgameJoinRenderState();
 
 	// Load the map with the snapshot. Setting savegamerestore triggers
 	// UnSnapshotLevel() inside G_InitNew(). Note: G_InitNew calls
@@ -2240,27 +2317,9 @@ void G_DoMidgameJoin()
 	// DEM_SETPITCHLIMIT from each player's console). For a mid-game joiner,
 	// remote players never re-send their pitch limits, so fix them now using
 	// the local renderer's pitch range.
+	for (size_t i = 0; i < MAXPLAYERS; ++i)
 	{
-		int uppitch, downpitch;
-		if (!V_IsHardwareRenderer())
-		{
-			int maxvp = min(56, (int)maxviewpitch);
-			int maxup = min(32, (int)maxviewpitch);
-			uppitch = cl_oldfreelooklimit ? maxup : maxvp;
-			downpitch = maxvp;
-		}
-		else
-		{
-			uppitch = downpitch = (int)maxviewpitch;
-		}
-		for (size_t i = 0; i < MAXPLAYERS; ++i)
-		{
-			if (playeringame[i] && players[i].mo)
-			{
-				players[i].MinPitch = DAngle::fromDeg(-(double)uppitch);
-				players[i].MaxPitch = DAngle::fromDeg((double)downpitch);
-			}
-		}
+		G_ApplyRendererPitchLimitsToPlayer((int)i);
 	}
 
 	if (globalsSize > 0)
@@ -2273,6 +2332,11 @@ void G_DoMidgameJoin()
 
 	// Synchronize network state with the host.
 	Net_PrepareMidgameSync();
+
+	// The late joiner is still not gameplay-active, but the snapshot world is
+	// loaded and can be rendered locally while waiting for DEM_MIDGAMESPAWN.
+	players[consoleplayer].camera = PickMidgameJoinRenderCamera();
+	bMidgameJoinRenderReady = (players[consoleplayer].camera != nullptr);
 
 	// Signal to the host that we've loaded successfully.
 	xfer.loadedSent = true;

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1999,6 +1999,64 @@ void C_SerializeCVars(FSerializer& arc, const char* label, uint32_t filter)
 	}
 }
 
+static void SerializeRestorableServerCVars(FSerializer& arc)
+{
+	if (arc.isReading())
+	{
+		FString cvar;
+		arc("importantcvars", cvar);
+		if (!cvar.IsEmpty())
+		{
+			auto vars_p = cvar.GetTArrayView();
+			C_ReadCVars(vars_p);
+		}
+		else
+		{
+			C_SerializeCVars(arc, "servercvars", CVAR_SERVERINFO);
+		}
+	}
+	else
+	{
+		C_SerializeCVars(arc, "servercvars", CVAR_SERVERINFO);
+	}
+}
+
+void G_SerializeMidgameGlobalsPreInit(FSerializer& arc)
+{
+	G_SerializeHub(arc);
+	SerializeRestorableServerCVars(arc);
+
+	arc("globalfreeze", globalfreeze)
+		("startpos", startpos)
+		("laststartpos", laststartpos);
+
+	if (arc.isWriting())
+		G_WriteVisited(arc);
+	else
+		G_ReadVisited(arc);
+}
+
+void G_SerializeMidgameGlobalsPostInit(FSerializer& arc)
+{
+	if (arc.isWriting())
+	{
+		FRandom::StaticWriteRNGState(arc);
+		P_WriteACSDefereds(arc);
+		P_WriteACSVars(arc);
+		if (NextSkill != -1)
+			arc("nextskill", NextSkill);
+	}
+	else
+	{
+		FRandom::StaticReadRNGState(arc);
+		P_ReadACSDefereds(arc);
+		P_ReadACSVars(arc);
+
+		NextSkill = -1;
+		arc("nextskill", NextSkill);
+	}
+}
+
 
 void SetupLoadingCVars();
 void FinishLoadingCVars();
@@ -2093,8 +2151,7 @@ void G_DoMidgameJoin()
 		return;
 	}
 
-	// Transfer data format: [globals (RNG state)] [snapshot header (16)] [compressed snapshot]
-	// The globals portion contains binary-serialized RNG state from the server.
+	// Transfer data format: [globals JSON blob] [snapshot header (16)] [compressed snapshot]
 	const size_t globalsSize = xfer.globalsSize;
 	const size_t totalSize = xfer.data.Size();
 	const size_t snapshotHeaderSize = 16;
@@ -2129,6 +2186,18 @@ void G_DoMidgameJoin()
 	info->Snapshot.mBuffer = new char[info->Snapshot.mCompressedSize];
 	memcpy(info->Snapshot.mBuffer, snapshotStart + snapshotHeaderSize, info->Snapshot.mCompressedSize);
 
+	FSerializer globalsArc;
+	if (globalsSize > 0 && !globalsArc.OpenReader(reinterpret_cast<const char*>(xfer.data.Data()), globalsSize))
+	{
+		Printf("G_DoMidgameJoin: failed to open globals blob (%zu bytes)\n", globalsSize);
+		info->Snapshot.Clean();
+		xfer.Clear();
+		return;
+	}
+
+	if (globalsSize > 0)
+		G_SerializeMidgameGlobalsPreInit(globalsArc);
+
 	// The joiner is NOT in the game yet — their slot will be activated via
 	// DEM_MIDGAMESPAWN after we signal STATE_LOADED.
 	playeringame[consoleplayer] = false;
@@ -2139,6 +2208,24 @@ void G_DoMidgameJoin()
 	savegamerestore = true;
 	G_InitNew(xfer.mapName.GetChars(), false);
 	savegamerestore = false;
+
+	// Automap discovery is local in normal multiplayer. A late joiner should
+	// start with no personal ML_MAPPED state instead of inheriting any host
+	// snapshot data, while ML_REVEALED and all-map effects remain intact.
+	for (auto& line : primaryLevel->lines)
+		line.flags &= ~ML_MAPPED;
+	for (auto& sub : primaryLevel->subsectors)
+		sub.flags &= ~SSECMF_DRAWN;
+
+	if (primaryLevel->automap != nullptr)
+	{
+		// The dedicated host serializes automap runtime state with no real
+		// display attached, so rebuild the automap from the local client's
+		// current resolution instead of trusting the snapshot values.
+		primaryLevel->automap->LevelInit();
+		primaryLevel->automap->ResetFollowLocation();
+		primaryLevel->automap->UpdateShowAllLines();
+	}
 
 	// Snapshot loading restores userinfo, but the palette translations still
 	// need to be rebuilt locally so existing players keep their skin colors.
@@ -2176,11 +2263,12 @@ void G_DoMidgameJoin()
 		}
 	}
 
-	// Restore the exact RNG state from the server at snapshot time.
-	// This must happen AFTER G_InitNew (which calls StaticClearRandom).
 	if (globalsSize > 0)
 	{
-		FRandom::StaticReadRNGBinary(xfer.data.Data(), globalsSize);
+		// The shared globals blob carries all session-level state that must
+		// match the host after G_InitNew() resets local runtime state.
+		G_SerializeMidgameGlobalsPostInit(globalsArc);
+		globalsArc.Close();
 	}
 
 	// Synchronize network state with the host.
@@ -2335,38 +2423,18 @@ void G_DoLoadGame ()
 	}
 
 
-	// Read intermission data for hubs
-	G_SerializeHub(arc);
-
 	primaryLevel->BotInfo.RemoveAllBots(primaryLevel, true);
 
 	savegamerestore = true;		// Use the player actors in the savegame
 
-	FString cvar;
-	arc("importantcvars", cvar);
-	if (!cvar.IsEmpty())
-	{
-		auto vars_p = cvar.GetTArrayView();
-		C_ReadCVars(vars_p);
-	}
-	else
-	{
-		C_SerializeCVars(arc, "servercvars", CVAR_SERVERINFO);
-	}
-
 	uint32_t time[2] = { 1,0 };
-
+	G_SerializeMidgameGlobalsPreInit(arc);
 	arc("ticrate", time[0])
-		("leveltime", time[1])
-		("globalfreeze", globalfreeze)
-		("startpos", startpos)
-		("laststartpos", laststartpos);
-	// dearchive all the modifications
+		("leveltime", time[1]);
 	level.time = Scale(time[1], TICRATE, time[0]);
 
 	G_ReadSnapshots(resfile.get());
 	resfile.reset(nullptr);	// we no longer need the resource file below this point
-	G_ReadVisited(arc);
 
 	// load a base level
 	bool demoplaybacksave = demoplayback;
@@ -2376,12 +2444,7 @@ void G_DoLoadGame ()
 	savegamerestore = false;
 
 	STAT_Serialize(arc);
-	FRandom::StaticReadRNGState(arc);
-	P_ReadACSDefereds(arc);
-	P_ReadACSVars(arc);
-
-	NextSkill = -1;
-	arc("nextskill", NextSkill);
+	G_SerializeMidgameGlobalsPostInit(arc);
 	Net_SetWaiting();
 
 	if (level.info != nullptr)
@@ -2672,9 +2735,7 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 	PutSaveWads (savegameinfo);
 	PutSaveComment (savegameinfo);
 
-	// Intermission stats for hubs
-	G_SerializeHub(savegameglobals);
-	C_SerializeCVars(savegameglobals, "servercvars", CVAR_SERVERINFO);
+	G_SerializeMidgameGlobalsPreInit(savegameglobals);
 
 	if (level.time != 0 || level.maptime != 0)
 	{
@@ -2683,21 +2744,8 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 		savegameglobals("leveltime", level.time);
 	}
 
-	savegameglobals("globalfreeze", globalfreeze)
-					("startpos", startpos)
-					("laststartpos", laststartpos);
-
 	STAT_Serialize(savegameglobals);
-	FRandom::StaticWriteRNGState(savegameglobals);
-	P_WriteACSDefereds(savegameglobals);
-	P_WriteACSVars(savegameglobals);
-	G_WriteVisited(savegameglobals);
-
-
-	if (NextSkill != -1)
-	{
-		savegameglobals("nextskill", NextSkill);
-	}
+	G_SerializeMidgameGlobalsPostInit(savegameglobals);
 
 	auto picdata = savepic.GetBuffer();
 	FCompressedBuffer bufpng = { picdata->size(), picdata->size(), FileSys::METHOD_STORED, static_cast<unsigned int>(crc32(0, &(*picdata)[0], picdata->size())), (char*)&(*picdata)[0] };

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2045,8 +2045,26 @@ void G_DoMidgameJoin()
 		if (!bMidgameStateRequested)
 		{
 			Printf("Requesting game state from host...\n");
-			uint8_t buf[2] = { NCMD_SETUP, PRE_MIDGAME_STATE_READY };
-			I_SendSetupPacket(Net_Arbitrator, buf, 2);
+			uint8_t buf[MAX_MSGLEN];
+			size_t pos = 0;
+			buf[pos++] = NCMD_SETUP;
+			buf[pos++] = PRE_MIDGAME_STATE_READY;
+
+			// Send our initial userinfo so the host can propagate the
+			// late joiner's name, skin, and colors before DEM_MIDGAMESPAWN.
+			const FString userinfo = D_GetUserInfoStrings(consoleplayer, true);
+			const size_t userinfoSize = userinfo.Len() + 1;
+			if (pos + userinfoSize > MAX_MSGLEN)
+			{
+				Printf("G_DoMidgameJoin: userinfo too large (%zu bytes)\n", userinfoSize);
+				G_AbortMidgameJoin();
+				return;
+			}
+
+			memcpy(&buf[pos], userinfo.GetChars(), userinfoSize);
+			pos += userinfoSize;
+
+			I_SendSetupPacket(Net_Arbitrator, buf, pos);
 			bMidgameStateRequested = true;
 			midgameJoinStartTime = I_msTime();
 		}
@@ -2117,10 +2135,18 @@ void G_DoMidgameJoin()
 
 	// Load the map with the snapshot. Setting savegamerestore triggers
 	// UnSnapshotLevel() inside G_InitNew(). Note: G_InitNew calls
-	// StaticClearRandom() which resets RNG — we restore it below.
+	// StaticClearRandom() which resets RNG; we restore it below.
 	savegamerestore = true;
 	G_InitNew(xfer.mapName.GetChars(), false);
 	savegamerestore = false;
+
+	// Snapshot loading restores userinfo, but the palette translations still
+	// need to be rebuilt locally so existing players keep their skin colors.
+	for (size_t i = 0; i < MAXPLAYERS; ++i)
+	{
+		if (playeringame[i])
+			R_BuildPlayerTranslation((int)i);
+	}
 
 	// Fix pitch limits for all players. ReadOnePlayer sets MinPitch=MaxPitch=
 	// current pitch as a temporary measure (the real limits arrive via

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -75,6 +75,8 @@ bool G_CheckDemoStatus (void);
 void G_Ticker (void);
 void G_DoMidgameJoin();
 void G_AbortMidgameJoin();
+bool G_CanRenderMidgameJoinView();
+void G_ClearMidgameJoinRenderState();
 bool G_Responder (event_t*	ev);
 
 enum
@@ -92,6 +94,7 @@ class FSerializer;
 bool G_CheckSaveGameWads (FSerializer &arc, bool printwarn);
 void G_SerializeMidgameGlobalsPreInit(FSerializer& arc);
 void G_SerializeMidgameGlobalsPostInit(FSerializer& arc);
+void G_ApplyRendererPitchLimitsToPlayer(int player);
 
 enum EFinishLevelType
 {

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -90,6 +90,8 @@ void G_StartSlideshow(FLevelLocals *Level, FName whichone, int state);
 
 class FSerializer;
 bool G_CheckSaveGameWads (FSerializer &arc, bool printwarn);
+void G_SerializeMidgameGlobalsPreInit(FSerializer& arc);
+void G_SerializeMidgameGlobalsPostInit(FSerializer& arc);
 
 enum EFinishLevelType
 {

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -828,10 +828,11 @@ void FLevelLocals::CopyPlayer(player_t *dst, player_t *src, const char *name)
 	uibackup.TransferFrom(dst->userinfo);
 	uibackup2.TransferFrom(src->userinfo);
 
-	int chasecam = dst->cheats & CF_CHASECAM;	// Remember the chasecam setting
-	bool attackdown = dst->attackdown;
-	bool usedown = dst->usedown;
 	const bool loadingMidgameJoinSnapshot = savegamerestore && netgame && !PlayerInGame(consoleplayer);
+	const bool preserveLocalInputState = !loadingMidgameJoinSnapshot || dst == &players[consoleplayer];
+	int chasecam = preserveLocalInputState ? (dst->cheats & CF_CHASECAM) : 0;	// Remember the chasecam setting
+	bool attackdown = preserveLocalInputState ? dst->attackdown : src->attackdown;
+	bool usedown = preserveLocalInputState ? dst->usedown : src->usedown;
 
 	dst->CopyFrom(*src);	// To avoid memory leaks at this point the userinfo in src must be empty which is taken care of by the TransferFrom call above.
 
@@ -878,7 +879,7 @@ void FLevelLocals::CopyPlayer(player_t *dst, player_t *src, const char *name)
 		pspr = pspr->Next;
 	}
 
-	// These 2 variables may not be overwritten.
+	// Preserve local edge-triggered input state only for the active local player.
 	dst->attackdown = attackdown;
 	dst->usedown = usedown;
 }

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -831,6 +831,7 @@ void FLevelLocals::CopyPlayer(player_t *dst, player_t *src, const char *name)
 	int chasecam = dst->cheats & CF_CHASECAM;	// Remember the chasecam setting
 	bool attackdown = dst->attackdown;
 	bool usedown = dst->usedown;
+	const bool loadingMidgameJoinSnapshot = savegamerestore && netgame && !PlayerInGame(consoleplayer);
 
 	dst->CopyFrom(*src);	// To avoid memory leaks at this point the userinfo in src must be empty which is taken care of by the TransferFrom call above.
 
@@ -852,7 +853,9 @@ void FLevelLocals::CopyPlayer(player_t *dst, player_t *src, const char *name)
 	}
 	else
 	{
-		dst->userinfo.TransferFrom(uibackup);
+		// Mid-game join snapshots must restore remote players' userinfo from the
+		// snapshot, not from the late joiner's pre-load placeholders/defaults.
+		dst->userinfo.TransferFrom(loadingMidgameJoinSnapshot ? uibackup2 : uibackup);
 		// The player class must come from the save, so that the menu reflects the currently playing one.
 		dst->userinfo.PlayerClassChanged(src->mo->GetInfo()->DisplayName.GetChars());
 	}
@@ -1153,4 +1156,3 @@ void FLevelLocals::UnSnapshotLevel(bool hubLoad)
 		Behaviors.UnlockLevelVarStrings(levelnum);
 	}
 }
-

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6482,7 +6482,7 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 
 	// Dedicated server ghost player (slot 0): make invisible and non-interactive
 	// so it doesn't block real players or appear as a visible model.
-	if ((dedicatedServer || hostIsDedicated) && playernum == 0)
+	if (Net_IsGhostPlayer(playernum))
 	{
 		mobj->renderflags |= RF_INVISIBLE;
 		mobj->flags &= ~(MF_SOLID | MF_SHOOTABLE);

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1049,17 +1049,17 @@ DEFINE_ACTION_FUNCTION_NATIVE(_PlayerInfo, GetNextPlayerNumber, player_t::GetNex
 	ACTION_RETURN_INT(player_t::GetNextPlayerNumber(pNum, noBots));
 }
 
-static int IsGhostPlayer(int pNum)
+static int VMIsGhostPlayer(int pNum)
 {
-	return (dedicatedServer || hostIsDedicated) && pNum == 0;
+	return Net_IsGhostPlayer(pNum);
 }
 
-DEFINE_ACTION_FUNCTION_NATIVE(_PlayerInfo, IsGhostPlayer, IsGhostPlayer)
+DEFINE_ACTION_FUNCTION_NATIVE(_PlayerInfo, IsGhostPlayer, VMIsGhostPlayer)
 {
 	PARAM_PROLOGUE;
 	PARAM_INT(pNum);
 
-	ACTION_RETURN_BOOL(IsGhostPlayer(pNum));
+	ACTION_RETURN_BOOL(Net_IsGhostPlayer(pNum));
 }
 
 static int GetFullbrightMode(player_t* self)

--- a/src/rendering/swrenderer/scene/r_scene.cpp
+++ b/src/rendering/swrenderer/scene/r_scene.cpp
@@ -84,6 +84,10 @@ namespace swrenderer
 
 	void RenderScene::RenderView(player_t *player, DCanvas *target, void *videobuffer, int bufferpitch)
 	{
+		auto viewactor = player->mo != nullptr ? player->mo : player->camera;
+		if (viewactor == nullptr || player->camera == nullptr)
+			return;
+
 		auto viewport = MainThread()->Viewport.get();
 		viewport->RenderTarget = target;
 		viewport->RenderingToCanvas = false;
@@ -113,7 +117,7 @@ namespace swrenderer
 			}
 		}
 
-		RenderActorView(player->mo, true, false);
+		RenderActorView(viewactor, true, false);
 
 		if (videobuffer != target->GetPixels())
 		{


### PR DESCRIPTION
## Summary
- separate the dedicated ghost host stream from real gameplay players and hibernate dedicated servers when no real players are connected
- rework mid-game joins into a renderable waiting phase with explicit activation, delayed real spawn, and activation-time sequence/consistency realignment
- fix late-join restore and activation edge cases, including renderer pitch-limit sync, pending-join consistency handling, and remote player snapshot input state
- add runtime network lag metrics and dump commands for dedicated vs lobby comparisons
- fix DEM_MIDGAMEACTIVE parsing so the command always consumes and skips its full three-byte payload

## Verification
- built Debug and Release during development
- rebuilt Debug after the DEM_MIDGAMEACTIVE parser fix
- manually verified dedicated late join, delayed activation, automap/cosmetics, idle hibernation, and dedicated vs lobby lag measurement flows during development